### PR TITLE
Bug fix #538 Chained Creations

### DIFF
--- a/data/cards/all-cards.json
+++ b/data/cards/all-cards.json
@@ -5782,14 +5782,6 @@
                 {
                     "name": "Indiglow Creeper",
                     "stub": "indiglow-creeper"
-                },
-                {
-                    "name": "Luminous Seedling",
-                    "stub": "luminous-seedling"
-                },
-                {
-                    "name": "Brilliant Thorn",
-                    "stub": "brilliant-thorn"
                 }
             ]
         },
@@ -6110,10 +6102,6 @@
                 {
                     "name": "Salamander Monk",
                     "stub": "salamander-monk"
-                },
-                {
-                    "name": "Salamander Monk Spirit",
-                    "stub": "salamander-monk-spirit"
                 }
             ]
         },

--- a/test/server/cards/ChainedCreations.spec.js
+++ b/test/server/cards/ChainedCreations.spec.js
@@ -10,8 +10,13 @@ describe('Chained Creations', function () {
                 },
                 player2: {
                     phoenixborn: 'coal-roarkwin',
-                    inPlay: ['masked-wolf', 'iron-worker', 'iron-rhino'],
-                    spellboard: ['empower', 'summon-masked-wolf', 'summon-iron-rhino']
+                    inPlay: ['masked-wolf', 'iron-worker', 'iron-rhino', 'salamander-monk-spirit'],
+                    spellboard: [
+                        'empower',
+                        'summon-masked-wolf',
+                        'summon-iron-rhino',
+                        'summon-salamander-monk'
+                    ]
                 }
             });
         });
@@ -29,6 +34,16 @@ describe('Chained Creations', function () {
             this.player1.clickCard(this.summonMaskedWolf); // exhaust
 
             expect(this.summonMaskedWolf.exhausted).toBe(true);
+        });
+
+        it('destroys Monk Spirit and cannot exhaust ready spell', function () {
+            this.player1.clickCard(this.chainedCreations); // play card
+            this.player1.clickPrompt('Play this action');
+            this.player1.clickDie(0);
+            this.player1.clickPrompt('Done');
+
+            this.player1.clickCard(this.salamanderMonkSpirit); // destroy
+            expect(this.player1).not.toBeAbleToSelect(this.summonSalamanderMonk);
         });
 
         it('damage unit and NOT exhaust ready spell', function () {


### PR DESCRIPTION
I added a test and removed the conjurations that Summon Salamander Monk and Summon Indiglow Creeper can't summon directly from all-cards.json. I confirmed that this doesn't stop decks from being considered invalid. **I am not sure if all-cards.json conjurations attribute is being used by any other functionality.**

Aside: Applying this change to the json config was annoying with Docker. I couldn't just do a normal rebuild (docker-compose build), I had to delete the container, then build from scratch.