### PR TITLE
Fix bug for selecting greyed out cards during First Five selection

### DIFF
--- a/server/game/gamesteps/setup/FirstFivePrompt.js
+++ b/server/game/gamesteps/setup/FirstFivePrompt.js
@@ -62,9 +62,10 @@ class FirstFivePrompt extends AllPlayerPrompt {
             );
             if (card.location == 'hand') {
                 player.moveCard(card, 'deck');
-            }
-            for (const c of player.deck.filter((c) => c.name == card.name)) {
-                this.selectableCards[player.name].push(c);
+
+                for (const c of player.deck.filter((c) => c.name == card.name)) {
+                    this.selectableCards[player.name].push(c);
+                }
             }
         }
         player.setSelectedCards(this.selectedCards[player.name]);


### PR DESCRIPTION
Error in logic meant that selecting a greyed out card would remove the greyed out effect on remaining cards with the same name in the deck. Now only cleans up selection if the selected card was in hand.