### PR TITLE
Initialise selected cards when setting up meditate prompt

### DIFF
--- a/server/game/gamesteps/MeditatePrompt.js
+++ b/server/game/gamesteps/MeditatePrompt.js
@@ -29,6 +29,7 @@ class MeditatePrompt extends UiPrompt {
 
         this.count = 0;
         this.levelState = {};
+        this.choosingPlayer.clearSelectedCards();
     }
 
     get cardSelected() {


### PR DESCRIPTION
Fix issue #690 by initialising selected cards in the constructor. This appeared to fix the issue with Particle Shield, though perhaps there is a lingering issue that is causing the selected cards to remain from a reaction on the previous turn.