### PR TITLE
Bug fix for unseen and terrifying

### DIFF
--- a/server/game/gamesteps/ChooseDefendersPrompt.js
+++ b/server/game/gamesteps/ChooseDefendersPrompt.js
@@ -62,7 +62,7 @@ class ChooseDefendersPrompt extends UiPrompt {
     highlightAttackers() {
         const allNonUnseenBlocked = this.attack.checkUnseen();
         const legalChoices = this.attack.battles
-            .filter((b) => !b.attacker.anyEffect('unseen') || allNonUnseenBlocked)
+            .filter((b) => !b.attacker.anyEffect('unseen') || (allNonUnseenBlocked && !this.selectedCard.isDefender))
             .map((b) => b.attacker)
             .filter((a) => this.selectedCard.canBlock(a));
         this.choosingPlayer.setSelectableCards(legalChoices);
@@ -162,7 +162,11 @@ class ChooseDefendersPrompt extends UiPrompt {
         } else {
             if (card.isAttacker && this.selectedCard) {
                 // check validity
-                if (card.anyEffect('unseen') && !this.attack.checkUnseen() && !this.selectedCard.isDefender) { 
+                if (card.anyEffect('unseen') && !this.attack.checkUnseen()) { 
+                    return false;
+                }
+
+                if (card.anyEffect('unseen') && this.attack.checkUnseen() && this.selectedCard.isDefender) { 
                     return false;
                 }
 

--- a/server/game/gamesteps/ChooseDefendersPrompt.js
+++ b/server/game/gamesteps/ChooseDefendersPrompt.js
@@ -162,7 +162,11 @@ class ChooseDefendersPrompt extends UiPrompt {
         } else {
             if (card.isAttacker && this.selectedCard) {
                 // check validity
-                if (card.anyEffect('unseen') && !this.attack.checkUnseen()) {
+                if (card.anyEffect('unseen') && !this.attack.checkUnseen() && !this.selectedCard.isDefender) { 
+                    return false;
+                }
+
+                if (!this.selectedCard.canBlock(card)) {
                     return false;
                 }
 

--- a/test/server/attack-unseen.spec.js
+++ b/test/server/attack-unseen.spec.js
@@ -95,6 +95,33 @@ describe('unseen', function () {
 
             expect(this.player1).toHaveDefaultPrompt();
         });
+
+        it("doesn't let a player change blockers to work around unseen", function () {
+            this.player1.clickAttack(this.coalRoarkwin);
+            this.player1.clickCard(this.ironWorker);
+            this.player1.clickCard(this.mindFogOwl);
+            this.player1.clickDone();
+            expect(this.player2).toHavePrompt('Choose a blocker');
+
+            this.player2.clickCard(this.anchornaut);
+            expect(this.player2).not.toBeAbleToSelect(this.mindFogOwl);
+            expect(this.player2).toBeAbleToSelect(this.ironWorker);
+
+            this.player2.clickCard(this.mindFogOwl);
+            expect(
+                this.game.attackState.battles.some((b) => b.attacker === this.mindFogOwl && b.guard)
+            ).toBe(false);
+
+            this.player2.clickCard(this.ironWorker);
+
+            this.player2.clickCard(this.anchornaut);
+            // you should not be able to reassign the anchornaut to block the owl
+            expect(this.player2).not.toBeAbleToSelect(this.mindFogOwl);
+            this.player2.clickCard(this.mindFogOwl);
+            expect(
+                this.game.attackState.battles.some((b) => b.attacker === this.mindFogOwl && b.guard)
+            ).toBe(false);
+        });
     });
 
     describe('must interact with terrifying', function () {

--- a/test/server/attack-unseen.spec.js
+++ b/test/server/attack-unseen.spec.js
@@ -96,4 +96,87 @@ describe('unseen', function () {
             expect(this.player1).toHaveDefaultPrompt();
         });
     });
+
+    describe('must interact with terrifying', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    phoenixborn: 'aradel-summergaard',
+                    inPlay: ['frostback-bear', 'mind-fog-owl'],
+                    dicepool: ['natural', 'natural', 'charm', 'charm']
+                },
+                player2: {
+                    phoenixborn: 'coal-roarkwin',
+                    inPlay: ['anchornaut', 'iron-worker', 'sunshield-sentry']
+                }
+            });
+        });
+
+        it('by blocking non-unseen first', function () {
+            this.player1.clickAttack(this.coalRoarkwin);
+            this.player1.clickCard(this.frostbackBear);
+            this.player1.clickCard(this.mindFogOwl);
+            this.player1.clickDone();
+            expect(this.player2).toHavePrompt('Choose a blocker');
+
+            this.player2.clickCard(this.anchornaut);
+            expect(this.player2).not.toBeAbleToSelect(this.mindFogOwl);
+            expect(this.player2).not.toBeAbleToSelect(this.frostbackBear);
+
+            this.player2.clickCard(this.mindFogOwl);
+            expect(
+                this.game.attackState.battles.some((b) => b.attacker === this.mindFogOwl && b.guard)
+            ).toBe(false);
+
+            this.player2.clickCard(this.ironWorker);
+            this.player2.clickCard(this.frostbackBear);
+            expect(
+                this.game.attackState.battles.some((b) => b.attacker === this.frostbackBear && b.guard)
+            ).toBe(true);
+
+            // now you can block the owl
+            expect(this.player2).toBeAbleToSelect(this.mindFogOwl);
+            this.player2.clickCard(this.mindFogOwl);
+            this.player2.clickDone();
+
+            this.player1.clickCard(this.mindFogOwl);
+            this.player1.clickCard(this.frostbackBear);
+
+            expect(this.player1).toHaveDefaultPrompt();
+        });
+
+        it('and charm power die is considered for terrifying', function () {
+            this.player1.clickDie(2);
+            this.player1.clickPrompt('Charm Dice Power');
+            this.player1.clickCard(this.ironWorker);
+            expect(this.ironWorker.attack).toBe(1);
+            this.player1.clickAttack(this.coalRoarkwin);
+            this.player1.clickCard(this.frostbackBear);
+            this.player1.clickCard(this.mindFogOwl);
+            this.player1.clickDone();
+            expect(this.player2).toHavePrompt('Choose a blocker');
+
+            this.player2.clickCard(this.anchornaut);
+            expect(this.player2).not.toBeAbleToSelect(this.mindFogOwl);
+            expect(this.player2).not.toBeAbleToSelect(this.frostbackBear);
+
+            this.player2.clickCard(this.frostbackBear);
+            expect(
+                this.game.attackState.battles.some((b) => b.attacker === this.frostbackBear && b.guard)
+            ).toBe(false);
+
+            this.player2.clickCard(this.anchornaut);
+
+            this.player2.clickCard(this.mindFogOwl);
+            expect(
+                this.game.attackState.battles.some((b) => b.attacker === this.mindFogOwl && b.guard)
+            ).toBe(false);
+
+            this.player2.clickCard(this.ironWorker);
+
+            // Charm power die means you can't block either attacker
+            expect(this.player2).not.toBeAbleToSelect(this.mindFogOwl);
+            expect(this.player2).not.toBeAbleToSelect(this.frostbackBear);
+        });
+    });
 });


### PR DESCRIPTION
The additional checks for validity will cause some issues when multiple unseen units are being blocked if the blocking player wants to reassign them. They will need to clear selections and start again. This is due to the code now checking only that we aren't reassigning a blocker to work around the CheckUnseen deficiency. Ideally, the check would confirm that the blocking reassignment would not lead to checkUnseen becoming false but I can't work out a simple way of doing this.