### PR TITLE
Fixed Secret Door check and other target restrictions

### DIFF
--- a/server/game/cards/Ashes-Core/Hypnotize.js
+++ b/server/game/cards/Ashes-Core/Hypnotize.js
@@ -14,6 +14,7 @@ class Hypnotize extends Card {
             ],
             target: {
                 cardType: ['Ally', 'Conjuration'],
+                controller: 'self',
                 gameAction: ability.actions.cardLastingEffect({
                     duration: 'untilEndOfTurn',
                     effect: ability.effects.gainAbility('persistentEffect', {

--- a/server/game/cards/Ashes-Core/NoahRedmoon.js
+++ b/server/game/cards/Ashes-Core/NoahRedmoon.js
@@ -12,7 +12,8 @@ class NoahRedmoon extends Card {
                 ability.costs.dice([new DiceCount(1, Level.Basic)])
             ],
             target: {
-                // target a ready spell, or if no units then the pb is valid
+                // target a ready spell
+                // (though technically the ability targets a PB so it should be able to be vanished)
                 cardType: [CardType.ReadySpell],
                 cardCondition: (card) => !card.exhausted,
                 controller: 'opponent',

--- a/server/game/cards/Ashes-Core/OutOfTheMist.js
+++ b/server/game/cards/Ashes-Core/OutOfTheMist.js
@@ -8,7 +8,6 @@ class OutOfTheMist extends Card {
             target: {
                 activePromptTitle: 'Choose a target',
                 cardType: ['Ally', 'Conjuration'],
-                controller: 'opponent',
                 gameAction: ability.actions.dealDamage((context) => ({
                     amount: context.player.unitsInPlay.length
                 }))

--- a/server/game/cards/Mixed-Expansions/LickWounds.js
+++ b/server/game/cards/Mixed-Expansions/LickWounds.js
@@ -5,7 +5,6 @@ class LickWounds extends Card {
     setupCardAbilities(ability) {
         this.play({
             target: {
-                controller: 'self',
                 cardType: [...BattlefieldTypes, CardType.Phoenixborn],
                 gameAction: [
                     ability.actions.removeDamage({ amount: 2 }),

--- a/server/game/cards/Mono-Expansions/SecretDoor.js
+++ b/server/game/cards/Mono-Expansions/SecretDoor.js
@@ -13,7 +13,7 @@ class SecretDoor extends Card {
             ],
             location: 'spellboard',
             target: {
-                cardCondition: (card, context) => card !== context.source,
+                cardCondition: (card, context) => card !== context.source && card.printedLife == 1,
                 controller: 'self',
                 cardType: BattlefieldTypes,
                 gameAction: ability.actions.cardLastingEffect(() => ({

--- a/server/game/cards/Mono-Expansions/ToShadows.js
+++ b/server/game/cards/Mono-Expansions/ToShadows.js
@@ -6,7 +6,6 @@ class ToShadows extends Card {
         this.play({
             target: {
                 activePromptTitle: 'Choose an exhausted unit to discard',
-                player: 'any',
                 cardType: BattlefieldTypes,
                 cardCondition: (card) => card.exhausted,
                 gameAction: ability.actions.discard()

--- a/server/game/cards/Time/HuntingWeapons.js
+++ b/server/game/cards/Time/HuntingWeapons.js
@@ -17,6 +17,7 @@ class HuntingWeapons extends Card {
                         optional: true,
                         activePromptTitle: 'Choose a unit to damage',
                         cardType: BattlefieldTypes,
+                        controller: 'opponent',
                         gameAction: ability.actions.dealDamage({
                             amount: 1
                         })

--- a/test/server/cards/SecretDoor.spec.js
+++ b/test/server/cards/SecretDoor.spec.js
@@ -3,7 +3,7 @@ describe('Secret Door', function () {
         this.setupTest({
             player1: {
                 phoenixborn: 'aradel-summergaard',
-                inPlay: ['crimson-bomber'],
+                inPlay: ['crimson-bomber', 'mist-spirit'],
                 spellboard: ['secret-door'],
                 dicepool: ['illusion']
             },
@@ -17,11 +17,13 @@ describe('Secret Door', function () {
     it('unit should be unblockable', function () {
         this.player1.clickCard(this.secretDoor);
         this.player1.clickPrompt('Secret Door a unit');
-        this.player1.clickCard(this.crimsonBomber);
+        expect(this.player1).not.toBeAbleToSelect(this.crimsonBomber);
+        expect(this.player1).toBeAbleToSelect(this.mistSpirit);
+        this.player1.clickCard(this.mistSpirit);
 
         this.player1.clickPrompt('Attack');
         this.player1.clickCard(this.coalRoarkwin);
-        this.player1.clickCard(this.crimsonBomber);
+        this.player1.clickCard(this.mistSpirit);
         this.player1.clickPrompt('Done');
         expect(this.player2).toHavePrompt('Waiting for opponent'); // defender didn't get option to block
     });
@@ -29,7 +31,7 @@ describe('Secret Door', function () {
     it('unit should be guardable', function () {
         this.player1.clickCard(this.secretDoor);
         this.player1.clickPrompt('Secret Door a unit');
-        this.player1.clickCard(this.crimsonBomber);
+        this.player1.clickCard(this.mistSpirit);
 
         this.player1.clickPrompt('Attack');
         this.player1.clickCard(this.hammerKnight);


### PR DESCRIPTION
Secret Door - now restricted to units with a printed life of 1
Hypnotize - restricted to own units
Noah - fixed comment
Out of the Mist - can target any units
Lick Wounds - can target any PB or units
To Shadows - removed designation of any player as this doesn't appear to do anything.
Hunting Weapons - ping restricted to opposing units
