### PR TITLE
Manual mode change active player fix #550

### DIFF
--- a/client/pages/About.jsx
+++ b/client/pages/About.jsx
@@ -105,16 +105,18 @@ class About extends React.Component {
                                 Move a card to play, spellboard, deck, discard, hand or conjuration (pile)
                             </Trans>
                         </li>
-                        <li>/purge - Choose a card to remove from the game.</li>
+                        <li>
+                            /passactive - Spend your main action and pass the active turn to your
+                            opponent
+                        </li>
+                        <li>/purge - Choose a card to remove from the game</li>
                         <li>
                             /rematch -{' '}
                             <Trans i18nKey='howtoplay.cmd.rematch'>
                                 Start over a new game with the current opponent
                             </Trans>
                         </li>
-                        <li>
-                            /reveal - Reveal a face down card
-                        </li>
+                        <li>/reveal - Reveal a face down card</li>
                         <li>
                             /shuffle -{' '}
                             <Trans i18nKey='howtoplay.cmd.shuffle'>Shuffle your deck</Trans>

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -22,6 +22,7 @@ class ChatCommands {
             '/move': this.moveCard,
             '/modifyclock': this.modifyClock, // hidden option
             '/mutespectators': this.muteSpectators, // hidden option
+            '/passactive': this.passActiveTurn, //hidden option
             '/purge': this.purgeCard,
             '/rematch': this.rematch,
             '/reveal': this.reveal,
@@ -227,6 +228,19 @@ class ChatCommands {
             : Object.keys(player.actions).filter((action) => player.actions[action])[0];
         this.game.addAlert('danger', '{0} sets their {1} action to unspent', player, actionType);
         player.actions[actionType] = true;
+    }
+
+    passActiveTurn(player) {
+        if (player === this.game.activePlayer) {
+            this.spendAction(player, ['', 'main']);
+            this.game.addAlert(
+                'danger',
+                '{0} passes the active turn to {1}',
+                player,
+                player.opponent
+            );
+            this.game.endTurn();
+        }
     }
 
     startClocks(player) {


### PR DESCRIPTION
/passactive command in manual mode for the active player now clears the main action and then passes the active turn to their opponent.