### PR TITLE
Bug fix #744 Fear now has heal message

### DIFF
--- a/server/game/cards/Ashes-Core/Fear.js
+++ b/server/game/cards/Ashes-Core/Fear.js
@@ -13,7 +13,8 @@ class Fear extends Card {
             then: {
                 gameAction: ability.actions.removeDamage((context) => ({
                     amount: context.preThenEvent.context.target.recover,
-                    target: context.source.owner.phoenixborn
+                    target: context.source.owner.phoenixborn,
+                    showMessage: true
                 })),
                 then: {
                     alwaysTriggers: true,


### PR DESCRIPTION
Fear now adds a message when it heals a wound from Jessa, along the lines of:
test1 plays Fear to destroy Blood Shaman
test1 uses Fear to remove 1 damage token from Jessa Na Ni