### PR TITLE
Phoenix Barrage and Copycat Improvements

### DIFF
--- a/server/game/cards/Mono-Expansions/Copycat.js
+++ b/server/game/cards/Mono-Expansions/Copycat.js
@@ -19,6 +19,10 @@ class Copycat extends Card {
         let result = context.event.context.ability;
         if (context.event.context.preThenEvent) {
             result = context.event.context.preThenEvent.context.ability;
+            // This next step aims to deal with effect then effect then effect (e.g. Phoenix Barrage)
+            if (context.event.context.preThenEvent.context.preThenEvent) {
+                result = context.event.context.preThenEvent.context.preThenEvent.context.ability;
+            }
         }
         return result;
     }

--- a/server/game/cards/Time/PhoenixBarrage.js
+++ b/server/game/cards/Time/PhoenixBarrage.js
@@ -16,7 +16,8 @@ class PhoenixBarrage extends Card {
                     activePromptTitle: 'Choose a second unit to damage',
                     cardType: BattlefieldTypes,
                     gameAction: ability.actions.dealDamage({
-                        amount: 2
+                        amount: 2,
+                        showMessage: true
                     })
                 },
                 then: {
@@ -24,7 +25,8 @@ class PhoenixBarrage extends Card {
                         activePromptTitle: 'Choose a phoenixborn to damage',
                         cardType: CardType.Phoenixborn,
                         gameAction: ability.actions.dealDamage({
-                            amount: 2
+                            amount: 2,
+                            showMessage: true
                         })
                     }
                 }

--- a/test/server/cards/Copycat.spec.js
+++ b/test/server/cards/Copycat.spec.js
@@ -180,8 +180,7 @@ describe('Copycat', function () {
         });
     });
 
-
-    describe('copy Open Memories', function () {
+    describe('copies actions', function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
@@ -189,11 +188,11 @@ describe('Copycat', function () {
                     inPlay: ['hammer-knight', 'blood-archer'],
                     dicepool: ['natural', 'natural', 'illusion', 'charm', 'charm'],
                     deck: ['molten-gold', 'redirect', 'out-of-the-mist', 'cover'],
-                    hand: ['open-memories']
+                    hand: ['open-memories', 'phoenix-barrage']
                 },
                 player2: {
                     phoenixborn: 'maeoni-viper',
-                    inPlay: ['glow-finch'],
+                    inPlay: ['glow-finch', 'silver-snake', 'false-demon'],
                     hand: ['copycat', 'dispel'],
                     dicepool: ['charm', 'natural', 'natural', 'illusion', 'charm', 'charm'],
                     deck: ['anchornaut', 'iron-worker', 'purge', 'one-hundred-blades']
@@ -201,7 +200,7 @@ describe('Copycat', function () {
             });
         });
 
-        it('check only triggers once (bug reported, not found)', function () {
+        it('check Open Memories only triggers once (bug reported, not found)', function () {
             this.player1.play(this.openMemories);
             this.player1.clickDie(0);
             this.player1.clickDone();
@@ -213,6 +212,26 @@ describe('Copycat', function () {
             this.player2.clickCard(this.ironWorker);
             expect(this.ironWorker.location).toBe('hand');
             expect(this.player1).toHaveDefaultPrompt();
+        });
+
+        it('Phoenix Barrage triggers completely', function () {
+            this.player1.play(this.phoenixBarrage);
+            this.player1.clickDie(0);
+            this.player1.clickDie(1);
+            this.player1.clickDie(2);
+            this.player1.clickDone();
+            this.player1.clickCard(this.silverSnake);
+            this.player1.clickCard(this.falseDemon);
+            this.player1.clickCard(this.maeoniViper);
+
+            this.player2.clickCard(this.copycat);
+            this.player2.clickDie(0);
+            this.player2.clickCard(this.hammerKnight);
+            this.player2.clickCard(this.bloodArcher);
+            this.player2.clickCard(this.coalRoarkwin);
+            expect(this.hammerKnight.damage).toBe(2);
+            expect(this.bloodArcher.damage).toBe(2);
+            expect(this.coalRoarkwin.damage).toBe(2);
         });
     });
 


### PR DESCRIPTION
Copycat now steps a further step up the preThenEvent chain, which allows it to start at the beginning of Phoenix Barrage.
Phoenix Barrage now provides messages beyond the first damage dealt, e.g.
test1 plays Phoenix Barrage to deal 2 damage to Flash Archer
Flash Archer is destroyed
Shadow Spirit takes 2 damage
Shadow Spirit is destroyed
Victoria Glassfire takes 2 damage
test2 plays Copycat to resolve Copycat's ability
test2 plays Phoenix Barrage to deal 2 damage to Emberoot Lizard
Emberoot Lizard is destroyed
Gorrenrock Brawler takes 2 damage
Lulu Firststone takes 2 damage