### PR TITLE
Bug fix #765 Blink issues

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -423,7 +423,7 @@ class Player extends GameObject {
             'Ready Spell': [...cardLocations, 'spellboard'], // To do: The Awakened State is a ready spell that starts in archives
             'Reaction Spell': [...cardLocations, 'being played'],
             Ally: [...cardLocations, 'play area'],
-            Conjuration: ['play area', 'archives'],
+            Conjuration: ['play area', 'archives', 'purged'],
             'Conjured Alteration Spell': ['play area', 'archives']
         };
 

--- a/test/server/cards/Blink.spec.js
+++ b/test/server/cards/Blink.spec.js
@@ -15,17 +15,15 @@ describe('Blink action spell', function () {
         });
     });
 
-    it('removes unit from play then returns at end of turn', function () {
-        expect(this.ironWorker.damage).toBe(0);
-
+    it('removes conjuration from play then returns at end of turn', function () {
         this.player1.play(this.blink);
         this.player1.clickDie(0);
-        this.player1.clickCard(this.ironWorker);
+        this.player1.clickCard(this.mistSpirit);
 
-        expect(this.ironWorker.location).toBe('purged');
+        expect(this.mistSpirit.location).toBe('purged');
 
         this.player1.endTurn();
-        expect(this.ironWorker.location).toBe('play area');
+        expect(this.mistSpirit.location).toBe('play area');
     });
 
     it('should allow enters play triggers', function () {


### PR DESCRIPTION
My previous reduction in valid card locations went too far for conjurations. Added the fix and a test for Blink to confirm that conjurations would be purged as the other tests already demonstrated the same for allies.