### PR TITLE
Fix #197

### DIFF
--- a/client/pages/About.jsx
+++ b/client/pages/About.jsx
@@ -116,6 +116,12 @@ class About extends React.Component {
                                 Start over a new game with the current opponent
                             </Trans>
                         </li>
+                        <li>
+                            /removeeffects -{' '}
+                            <Trans i18nKey='howtoplay.cmd.removeeffects'>
+                                Remove temporary effects from a card in play
+                            </Trans>
+                        </li>
                         <li>/reveal - Reveal a face down card</li>
                         <li>
                             /shuffle -{' '}

--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -82,7 +82,8 @@ class Card extends PlayableObject {
             { command: 'remGravityFlux', text: 'Remove gravity flux exhaustion', menu: 'tokens' },
             { command: 'moveHand', text: 'Move to hand', menu: 'moves' },
             { command: 'moveDiscard', text: 'Move to discard', menu: 'moves' },
-            { command: 'movePlay', text: 'Move to play area', menu: 'moves' }
+            { command: 'movePlay', text: 'Move to play area', menu: 'moves' },
+            { command: 'remEffects', text: 'Remove temporary effects', menu: 'main' }
         ];
         if (ConjuredCardTypes.includes(this.type)) {
             this.menu.push({ command: 'moveConjuration', text: 'Move to conjuration pile', menu: 'moves' });

--- a/server/game/MenuCommands.js
+++ b/server/game/MenuCommands.js
@@ -36,6 +36,10 @@ class MenuCommands {
                 game.addAlert('danger', '{0} removes gravity flux exhaustion from {1}', player, card);
                 card.removeToken('gravityFlux', 1);
                 break;
+            case 'remEffects':
+                game.addAlert('danger', '{0} removes temporary effects from {1}', player, card);
+                card.removeLastingEffects();
+                break;
             // I can't click on cards in my Discard pile in manual mode and receive a menu
             // In manual mode, I can't click on cards in hand and receive a menu (drag & drop required)
             case 'moveHand':
@@ -87,7 +91,6 @@ class MenuCommands {
                         card
                     );
                 }
-
                 break;
             case 'guarded':
                 card.usedGuardThisRound = !card.usedGuardThisRound;
@@ -98,7 +101,6 @@ class MenuCommands {
                     card,
                     card.usedGuardThisRound ? 'true' : 'false'
                 );
-
                 break;
             case 'detachDie':
                 if (card.dieUpgrades.length === 1) {
@@ -112,7 +114,6 @@ class MenuCommands {
                     );
                     return true;
                 }
-
                 break;
             case 'attach':
                 game.promptForSelect(player, {
@@ -129,7 +130,6 @@ class MenuCommands {
                         return true;
                     }
                 });
-
                 break;
         }
     }

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -25,6 +25,7 @@ class ChatCommands {
             '/passactive': this.passActiveTurn, //hidden option
             '/purge': this.purgeCard,
             '/rematch': this.rematch,
+            '/removeeffects': this.removeEffects,
             '/reveal': this.reveal,
             '/shuffle': this.shuffle,
             '/stopclocks': this.stopClocks, // hidden option
@@ -204,6 +205,20 @@ class ChatCommands {
                 }
             });
         }
+    }
+
+    removeEffects(player) {
+        this.game.promptForSelect(player, {
+            location: ['play area'],
+            cardType: ['Ally', 'Conjuration'],
+            controller: 'self',
+            activePromptTitle: 'Select a card to remove effects from',
+            onSelect: (player, card) => {
+                this.game.addAlert('danger', '{0} removes temporary effects from {1}', player, card);
+                card.removeLastingEffects();
+                return true;
+            }
+        });
     }
 
     spendAction(player, args) {


### PR DESCRIPTION
Manual mode can now remove all temporary effects, either from the card menu or via chat commands. Confirmed to work for simple effects such as strengthen, intimidate and body inversion.