### PR TITLE
Show messages for Awakened State dealing damage

### DIFF
--- a/server/game/cards/Time/TheAwakenedState.js
+++ b/server/game/cards/Time/TheAwakenedState.js
@@ -18,6 +18,7 @@ class TheAwakenedState extends Card {
                 gameAction: [
                     ability.actions.dealDamage({
                         amount: 1,
+                        showMessage: true,
                         promptForSelect: {
                             controller: 'opponent',
                             activePromptTitle: 'Deal 1 damage',
@@ -26,6 +27,7 @@ class TheAwakenedState extends Card {
                     }),
                     ability.actions.dealDamage((context) => ({
                         amount: 1,
+                        showMessage: true,
                         target: context.player.opponent.phoenixborn
                     }))
                 ]


### PR DESCRIPTION
Untested, but should work. I noticed spectating a match just now that Awakened State wasn't creating messages for the damage dealt.