### PR TITLE
Use BattlefieldTypes consistently on cards

### DIFF
--- a/server/game/cards/Ashes-Core/Anchornaut.js
+++ b/server/game/cards/Ashes-Core/Anchornaut.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class Anchornaut extends Card {
     setupCardAbilities(ability) {
@@ -9,7 +10,7 @@ class Anchornaut extends Card {
                 optional: true,
                 cardCondition: (card, context) => card !== context.source,
                 activePromptTitle: 'Throw 1',
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 gameAction: ability.actions.dealDamage({
                     amount: 1
                 })

--- a/server/game/cards/Ashes-Core/BloodArcher.js
+++ b/server/game/cards/Ashes-Core/BloodArcher.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class BloodArcher extends Card {
     setupCardAbilities(ability) {
@@ -12,7 +13,7 @@ class BloodArcher extends Card {
             then: {
                 target: {
                     activePromptTitle: 'Blood Shot',
-                    cardType: ['Ally', 'Conjuration'],
+                    cardType: BattlefieldTypes,
                     gameAction: ability.actions.dealDamage({ amount: 1, showMessage: true })
                 }
             }

--- a/server/game/cards/Ashes-Core/ButterflyMonk.js
+++ b/server/game/cards/Ashes-Core/ButterflyMonk.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes, CardType } = require('../../../constants.js');
 
 class ButterflyMonk extends Card {
     setupCardAbilities(ability) {
@@ -10,7 +11,7 @@ class ButterflyMonk extends Card {
                 optional: true,
                 cardCondition: (card, context) => card !== context.source,
                 activePromptTitle: 'Mend 1',
-                cardType: ['Ally', 'Conjuration', 'Phoenixborn'],
+                cardType: [...BattlefieldTypes, CardType.Phoenixborn],
                 gameAction: ability.actions.removeDamage()
             }
         });

--- a/server/game/cards/Ashes-Core/CloseCombat.js
+++ b/server/game/cards/Ashes-Core/CloseCombat.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class CloseCombat extends Card {
     setupCardAbilities(ability) {
@@ -6,14 +7,14 @@ class CloseCombat extends Card {
             targets: {
                 myChar: {
                     activePromptTitle: 'Select a card for attack value',
-                    cardType: ['Ally', 'Conjuration'],
+                    cardType: BattlefieldTypes,
                     controller: 'self',
                     cardCondition: (card) => !card.exhausted
                 },
                 oppChar: {
                     dependsOn: 'myChar',
                     activePromptTitle: 'Choose a unit to damage',
-                    cardType: ['Ally', 'Conjuration'],
+                    cardType: BattlefieldTypes,
                     controller: 'opponent',
                     gameAction: ability.actions.dealDamage((context) => ({
                         amount: context.targets.myChar.attack

--- a/server/game/cards/Ashes-Core/CoalRoarkwin.js
+++ b/server/game/cards/Ashes-Core/CoalRoarkwin.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes, CardType } = require('../../../constants.js');
 
 class CoalRoarkwin extends Card {
     setupCardAbilities(ability) {
@@ -8,10 +9,10 @@ class CoalRoarkwin extends Card {
             target: {
                 // target a Unit, or if no units then the pb is valid
                 activePromptTitle: 'Choose a target to Slash',
-                cardType: ['Ally', 'Conjuration', 'Phoenixborn'],
+                cardType: [...BattlefieldTypes, CardType.Phoenixborn],
                 cardCondition: (card) => {
                     return (
-                        ['Ally', 'Conjuration'].includes(card.type) ||
+                        BattlefieldTypes.includes(card.type) ||
                         card.controller.cardsInPlay.length == 0 // implies the cardtype is pb
                     );
                 },

--- a/server/game/cards/Ashes-Core/HammerKnight.js
+++ b/server/game/cards/Ashes-Core/HammerKnight.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class HammerKnight extends Card {
     setupCardAbilities(ability) {
@@ -10,7 +11,7 @@ class HammerKnight extends Card {
                 optional: true,
                 activePromptTitle: 'Aftershock 1',
                 waitingPromptTitle: 'Aftershock 1: waiting for opponent',
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 cardCondition: (card, context) => card !== context.event.card,
                 gameAction: ability.actions.dealDamage({ amount: 1 })
             }

--- a/server/game/cards/Ashes-Core/Hypnotize.js
+++ b/server/game/cards/Ashes-Core/Hypnotize.js
@@ -1,4 +1,4 @@
-const { Level, Magic } = require('../../../constants.js');
+const { BattlefieldTypes, Level, Magic } = require('../../../constants.js');
 const Card = require('../../Card.js');
 const DiceCount = require('../../DiceCount.js');
 
@@ -13,7 +13,7 @@ class Hypnotize extends Card {
                 ability.costs.dice([new DiceCount(2, Level.Class, Magic.Charm)])
             ],
             target: {
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 controller: 'self',
                 gameAction: ability.actions.cardLastingEffect({
                     duration: 'untilEndOfTurn',

--- a/server/game/cards/Ashes-Core/MaeoniViper.js
+++ b/server/game/cards/Ashes-Core/MaeoniViper.js
@@ -1,4 +1,4 @@
-const { Level } = require('../../../constants.js');
+const { BattlefieldTypes, Level } = require('../../../constants.js');
 const Card = require('../../Card.js');
 const DiceCount = require('../../DiceCount.js');
 
@@ -17,14 +17,14 @@ class MaeoniViper extends Card {
             targets: {
                 myChar: {
                     activePromptTitle: 'Choose an unexhausted unit.',
-                    cardType: ['Ally', 'Conjuration'],
+                    cardType: BattlefieldTypes,
                     controller: 'self',
                     cardCondition: (card) => !card.exhausted
                 },
                 oppChar: {
                     dependsOn: 'myChar',
                     activePromptTitle: 'Choose a unit to damage',
-                    cardType: ['Ally', 'Conjuration'],
+                    cardType: BattlefieldTypes,
                     controller: 'opponent',
                     gameAction: ability.actions.dealDamage((context) => ({
                         amount: context.targets.myChar.attack

--- a/server/game/cards/Ashes-Core/MoltenGold.js
+++ b/server/game/cards/Ashes-Core/MoltenGold.js
@@ -1,11 +1,12 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes, CardType } = require('../../../constants.js');
 
 class MoltenGold extends Card {
     setupCardAbilities(ability) {
         this.play({
             title: 'Molten Gold',
             target: {
-                cardType: ['Ally', 'Conjuration', 'Phoenixborn'],
+                cardType: [...BattlefieldTypes, CardType.Phoenixborn],
                 gameAction: ability.actions.addDamageToken({ amount: 3 })
             }
         });

--- a/server/game/cards/Ashes-Core/OutOfTheMist.js
+++ b/server/game/cards/Ashes-Core/OutOfTheMist.js
@@ -1,11 +1,12 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class OutOfTheMist extends Card {
     setupCardAbilities(ability) {
         this.play({
             target: {
                 activePromptTitle: 'Choose a target',
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 gameAction: ability.actions.dealDamage((context) => ({
                     amount: context.player.unitsInPlay.length
                 }))

--- a/server/game/cards/Ashes-Core/SeasideRaven.js
+++ b/server/game/cards/Ashes-Core/SeasideRaven.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class SeasideRaven extends Card {
     setupCardAbilities(ability) {
@@ -7,7 +8,7 @@ class SeasideRaven extends Card {
             target: {
                 optional: true,
                 activePromptTitle: 'Prey 2',
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 controller: 'any',
                 cardCondition: (card) => card.life <= 2,
                 gameAction: ability.actions.destroy()

--- a/server/game/cards/Ashes-Core/ShadowStrike.js
+++ b/server/game/cards/Ashes-Core/ShadowStrike.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class ShadowStrike extends Card {
     setupCardAbilities(ability) {
@@ -12,7 +13,7 @@ class ShadowStrike extends Card {
             },
             effect: 'deal 3 damage to a non-attacker',
             target: {
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 controller: 'opponent',
                 cardCondition: (card, context) => this.notAttacking(card, context.event.battles),
                 gameAction: ability.actions.dealDamage({ amount: 3 })

--- a/server/game/cards/Ashes-Core/Strengthen.js
+++ b/server/game/cards/Ashes-Core/Strengthen.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class Strengthen extends Card {
     setupCardAbilities(ability) {
@@ -7,7 +8,7 @@ class Strengthen extends Card {
             cost: [ability.costs.sideAction(), ability.costs.exhaust()],
             location: 'spellboard',
             target: {
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 gameAction: ability.actions.cardLastingEffect((context) => ({
                     duration: 'untilEndOfTurn',
                     effect: ability.effects.modifyAttack(context.source.focus >= 2 ? 3 : 2)

--- a/server/game/cards/Ashes-Core/SympathyPain.js
+++ b/server/game/cards/Ashes-Core/SympathyPain.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes, CardType } = require('../../../constants.js');
 
 class SympathyPain extends Card {
     setupCardAbilities(ability) {
@@ -14,7 +15,7 @@ class SympathyPain extends Card {
             },
             effect: "deal 2 damage to oppponent's unit or phoenixborn",
             target: {
-                cardType: ['Ally', 'Conjuration', 'Phoenixborn'],
+                cardType: [...BattlefieldTypes, CardType.Phoenixborn],
                 controller: 'opponent',
                 gameAction: ability.actions.dealDamage({ amount: 2 })
             }

--- a/server/game/cards/Deluxe/OdetteDiamondcrest.js
+++ b/server/game/cards/Deluxe/OdetteDiamondcrest.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class OdetteDiamondcrest extends Card {
     setupCardAbilities(ability) {
@@ -6,7 +7,7 @@ class OdetteDiamondcrest extends Card {
             title: 'Enter the Fray',
             cost: [ability.costs.mainAction(), ability.costs.exhaust()],
             target: {
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 controller: 'any',
                 gameAction: [
                     ability.actions.dealDamage({ amount: 2 }),

--- a/server/game/cards/Mixed-Expansions/HuntMaster.js
+++ b/server/game/cards/Mixed-Expansions/HuntMaster.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class HuntMaster extends Card {
     setupCardAbilities(ability) {
@@ -15,7 +16,7 @@ class HuntMaster extends Card {
             title: 'Guide 1',
             cost: [ability.costs.sideAction(), ability.costs.loseStatus()],
             target: {
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 controller: 'self',
                 cardCondition: (card, context) => card !== context.source,
                 gameAction: ability.actions.cardLastingEffect({

--- a/server/game/cards/Mixed-Expansions/PainShaman.js
+++ b/server/game/cards/Mixed-Expansions/PainShaman.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes, CardType } = require('../../../constants.js');
 
 class PainShaman extends Card {
     setupCardAbilities(ability) {
@@ -7,7 +8,7 @@ class PainShaman extends Card {
             target: {
                 optional: true,
                 activePromptTitle: 'Choose a unit to damage',
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 gameAction: ability.actions.dealDamage({
                     amount: 1
                 })
@@ -15,7 +16,7 @@ class PainShaman extends Card {
             then: {
                 target: {
                     activePromptTitle: 'Choose a unit or Phoenixborn to heal',
-                    cardType: ['Ally', 'Conjuration', 'Phoenixborn'],
+                    cardType: [...BattlefieldTypes, CardType.Phoenixborn],
                     optional: true,
                     gameAction: ability.actions.removeDamage({
                         amount: 1,

--- a/server/game/cards/Mixed-Expansions/SonicSwordsman.js
+++ b/server/game/cards/Mixed-Expansions/SonicSwordsman.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants');
 
 class SonicSwordsman extends Card {
     setupCardAbilities(ability) {
@@ -9,7 +10,7 @@ class SonicSwordsman extends Card {
                 optional: true,
                 activePromptTitle: 'Sonic Pulse 1',
                 waitingPromptTitle: 'Sonic Pulse 1: waiting for opponent',
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 gameAction: ability.actions.exhaust()
             }
         });

--- a/server/game/cards/Mono-Expansions/BodyInversion.js
+++ b/server/game/cards/Mono-Expansions/BodyInversion.js
@@ -1,4 +1,4 @@
-const { Level, Magic } = require('../../../constants.js');
+const { BattlefieldTypes, Level, Magic } = require('../../../constants.js');
 const Card = require('../../Card.js');
 const DiceCount = require('../../DiceCount.js');
 
@@ -13,7 +13,7 @@ class BodyInversion extends Card {
                 ability.costs.dice([new DiceCount(1, Level.Class, Magic.Illusion)])
             ],
             target: {
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 gameAction: ability.actions.cardLastingEffect((context) => ({
                     duration: 'untilEndOfTurn',
                     effect: [

--- a/server/game/cards/Time/Spark.js
+++ b/server/game/cards/Time/Spark.js
@@ -1,4 +1,5 @@
 const Card = require('../../Card.js');
+const { BattlefieldTypes } = require('../../../constants.js');
 
 class Spark extends Card {
     setupCardAbilities(ability) {
@@ -11,7 +12,7 @@ class Spark extends Card {
             title: 'Spark',
             cost: [ability.costs.mainAction()],
             target: {
-                cardType: ['Ally', 'Conjuration'],
+                cardType: BattlefieldTypes,
                 controller: 'any',
                 gameAction: [
                     ability.actions.discard({ target: this }),


### PR DESCRIPTION
There is no difference in functionality; this was just consistently applying BattlefieldTypes to a range of cards instead of listing Ally and Conjuration