### PR TITLE
Bug fix #777 Phoenix Barrage and Vanish reaction message isn't correct

### DIFF
--- a/server/game/cards/Mono-Expansions/Copycat.js
+++ b/server/game/cards/Mono-Expansions/Copycat.js
@@ -19,7 +19,7 @@ class Copycat extends Card {
         let result = context.event.context.ability;
         if (context.event.context.preThenEvent) {
             result = context.event.context.preThenEvent.context.ability;
-            // This next step aims to deal with effect then effect then effect (e.g. Phoenix Barrage)
+            // This next step deals with effect, then effect, then effect (e.g. Phoenix Barrage)
             if (context.event.context.preThenEvent.context.preThenEvent) {
                 result = context.event.context.preThenEvent.context.preThenEvent.context.ability;
             }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -906,7 +906,7 @@ class Game extends EventEmitter {
     }
 
     /*
-     * Resolves a card ability or ring effect
+     * Resolves a card ability
      * @param {AbilityContext} context - see AbilityContext
      * @returns {undefined}
      */
@@ -947,7 +947,7 @@ class Game extends EventEmitter {
 
     /**
      * Creates an EventWindow which will open windows for each kind of triggered
-     * ability which can respond any passed events, and execute their handlers.
+     * ability which can respond to any passed events, and execute their handlers.
      * @param event
      * @returns {EventWindow}
      */

--- a/server/game/gamesteps/triggeredabilitywindowtitles.js
+++ b/server/game/gamesteps/triggeredabilitywindowtitles.js
@@ -28,9 +28,10 @@ const AbilityTypeToWord = {
 
 function GetTargettingTitlePhrase(event, player) {
     let myEvent = event;
-    if (event.context.preThenEvent && event.context.preThenEvent.name !== 'unnamedEvent') {
-        myEvent = event.context.preThenEvent;
-    }
+    //if (event.context.preThenEvent && event.context.preThenEvent.name !== 'unnamedEvent') { // original
+    //if (event.context.preThenEvent && event.context.preThenEvent.name !== 'unnamedEvent' && event.context.preThenEvent.context.ability.abilityType === 'action') { //Update only for Song of Sorrow and similar card abilities
+    //    myEvent = event.context.preThenEvent;
+    //}
     const abilityTitle = myEvent.context.ability.title || myEvent.context.source.name;
     // are there any of the players units / pb to name drop
     let targetList = '';

--- a/test/server/cards/Copycat.spec.js
+++ b/test/server/cards/Copycat.spec.js
@@ -240,6 +240,10 @@ describe('Copycat', function () {
             this.player1.clickCard(this.falseDemon);
             this.player1.clickCard(this.maeoniViper);
 
+            expect(this.player2).toHavePrompt(
+                'Any Reactions?' //menuTitle Any Reactions? for Copycat
+            );
+
             this.player2.clickCard(this.copycat);
             this.player2.clickDie(0);
             this.player2.clickCard(this.hammerKnight);

--- a/test/server/cards/Vanish.spec.js
+++ b/test/server/cards/Vanish.spec.js
@@ -1,12 +1,12 @@
 describe('Vanish', function () {
-    describe('Vanish', function () {
+    describe('', function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {
                     phoenixborn: 'maeoni-viper',
                     inPlay: ['enchanted-violinist'],
                     dicepool: ['ceremonial', 'natural', 'natural', 'charm'],
-                    hand: ['molten-gold', 'one-hundred-blades']
+                    hand: ['molten-gold', 'one-hundred-blades', 'phoenix-barrage']
                 },
                 player2: {
                     phoenixborn: 'rin-northfell',
@@ -53,18 +53,42 @@ describe('Vanish', function () {
             this.player1.clickCard(this.mistSpirit);
             expect(this.mistSpirit.location).toBe('archives');
 
-            expect(this.player2).toHavePrompt(
-                'Any Reactions to Song of Sorrow targetting mist spirit?'
-            );
+            //expect(this.player2).toHavePrompt(
+            //    'Any Reactions to Song of Sorrow targetting mist spirit?'
+            //);
+
+            expect(this.player2).toHavePrompt('Any Reactions to Enchanted Violinist?');
+
             this.player2.clickCard(this.vanish);
 
             expect(this.rinNorthfell.damage).toBe(0);
             expect(this.player1).toHaveDefaultPrompt();
             expect(this.player2.hand.length).toBe(handSize - 1);
         });
+
+        it('cancels Phoenix Barrage part 3', function () {
+            this.player1.play(this.phoenixBarrage);
+            this.player1.clickDie(0);
+            this.player1.clickDie(1);
+            this.player1.clickDie(2);
+            this.player1.clickPrompt('Done');
+            this.player1.clickCard(this.hammerKnight);
+            //this.player1.clickCard(this.mistSpirit);
+            //expect(this.mistSpirit.location).toBe('archives');
+            this.player1.clickCard(this.hammerKnight);
+            this.player1.clickCard(this.rinNorthfell);
+
+            expect(this.player2).toHavePrompt(
+                'Any Reactions to Phoenix Barrage targetting Rin Northfell?'
+            );
+            this.player2.clickCard(this.vanish);
+
+            expect(this.rinNorthfell.damage).toBe(0);
+            expect(this.player1).toHaveDefaultPrompt();
+        });
     });
 
-    describe('Vanish', function () {
+    describe('', function () {
         beforeEach(function () {
             this.setupTest({
                 player1: {


### PR DESCRIPTION
As described in the targetting, I'm not sure what the intended functionality of GetTargettingTitlePhrase's first if statement was. It appears to assume if there is a good preThen event, that title should be presented to the player instead. The only test where this was relevant was Enchanted Violinist's Shared Sorrow, where it made Vanish appear as if it could react to the 1 damage being dealt, which is not really correct; Vanish is responding to the effect targetting the player in order to discard a card from their deck. So I think just commenting that out is fine, but please confirm if there is something I'm missing.