### PR TITLE
Bug fix #766 Rins Fury destroys defending unit

### DIFF
--- a/server/game/cards/Mono-Expansions/RinsFury.js
+++ b/server/game/cards/Mono-Expansions/RinsFury.js
@@ -20,6 +20,7 @@ class RinsFury extends Card {
                 target: {
                     cardType: BattlefieldTypes,
                     autoTarget: () => context.event.damageSource,
+                    controller: 'opponent',
                     gameAction: ability.actions.destroy()
                 }
             })

--- a/test/server/cards/RinsFury.spec.js
+++ b/test/server/cards/RinsFury.spec.js
@@ -94,9 +94,12 @@ describe('rins fury reaction spell', function () {
         expect(this.rinsFury.location).toBe('discard');
         expect(this.player2.hand.length).toBe(0);
 
-        // attacker destroyed
+        // attacker isn't destroyed
         expect(this.squallStallion.location).toBe('play area');
         expect(this.squallStallion.damage).toBe(0);
+
+        // defender isn't destroyed (Squall Stallion bug #766 with Rin's Fury)
+        expect(this.hammerKnight.location).toBe('play area');
         expect(this.hammerKnight.damage).toBe(0);
     });
 
@@ -118,9 +121,12 @@ describe('rins fury reaction spell', function () {
         expect(this.rinsFury.location).toBe('discard');
         expect(this.player2.hand.length).toBe(0);
 
-        // attacker destroyed
+        // attacker isn't destroyed
         expect(this.stormwindSniper.location).toBe('play area');
         expect(this.stormwindSniper.damage).toBe(0);
+
+        // defender isn't destroyed (Squall Stallion bug #766 with Rin's Fury)
+        expect(this.hammerKnight.location).toBe('play area');
         expect(this.hammerKnight.damage).toBe(0);
     });
 });


### PR DESCRIPTION
Forcing the target to be controlled by the opponent meant that autotarget would fail rather than accidentally target the defending unit