### PR TITLE
Bug fix #803 Gorrenrock Brawler and unit death on the subsequent turn

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -879,6 +879,12 @@ class Game extends EventEmitter {
 
     beginTurn() {
         this.betweenTurns = false;
+        // Would be better to have this refresh during endTurn, but couldn't work out how to ensure reset after other endTurn effects
+        this.cardsInPlay.forEach((c) => {
+            c.wasAttacker = false;
+            c.wasDefender = false;
+        });
+
         this.raiseEvent('onBeginTurn', { player: this.activePlayer });
         if (this.triggerSuddenDeath && this.activePlayer === this.roundFirstPlayer) {
             this.triggerSuddenDeath = false;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -279,8 +279,6 @@ class Player extends GameObject {
     beginTurn() {
         this.cardsInPlay.forEach((c) => {
             c.new = false;
-            c.wasAttacker = false;
-            c.wasDefender = false;
 
             c.upgrades.forEach((u) => (u.new = false));
         });
@@ -326,11 +324,9 @@ class Player extends GameObject {
         }
         this.limitedPlayed = 0; // reset for opponent's turn
         this.cardsInPlay.forEach((c) => {
-            //c.new = false;
-            c.wasAttacker = false;
-            c.wasDefender = false;
+            c.new = false;
 
-            //c.upgrades.forEach((u) => (u.new = false));
+            c.upgrades.forEach((u) => (u.new = false));
         });
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -325,6 +325,13 @@ class Player extends GameObject {
             this.game.addAlert('info', '{0} PASSES their main action', this);
         }
         this.limitedPlayed = 0; // reset for opponent's turn
+        this.cardsInPlay.forEach((c) => {
+            //c.new = false;
+            c.wasAttacker = false;
+            c.wasDefender = false;
+
+            //c.upgrades.forEach((u) => (u.new = false));
+        });
     }
 
     endRound() {

--- a/test/server/cards/GorrenrockBrawler.spec.js
+++ b/test/server/cards/GorrenrockBrawler.spec.js
@@ -48,8 +48,8 @@ describe('Gorrenrock Brawler', function () {
                 },
                 player2: {
                     phoenixborn: 'brennen-blackcloud',
-                    dicepool: ['ceremonial', 'time', 'charm', 'charm'],
-                    hand: ['molten-gold'],
+                    dicepool: ['ceremonial', 'time', 'charm', 'charm', 'illusion'],
+                    hand: ['molten-gold', 'strange-copy'],
                     inPlay: ['flute-mage', 'dread-wraith']
                 }
             });
@@ -59,6 +59,7 @@ describe('Gorrenrock Brawler', function () {
             expect(this.gorrenrockBrawler.status).toBe(0);
             this.player1.clickAttack(this.fluteMage);
             this.player1.clickCard(this.gorrenrockBrawler);
+            this.player2.clickPrompt('Pass'); // no strange copy
             this.player2.clickDone(); // no guard
             this.player2.clickYes();
 
@@ -72,6 +73,7 @@ describe('Gorrenrock Brawler', function () {
             expect(this.gorrenrockBrawler.status).toBe(0);
             this.player1.clickAttack(this.dreadWraith);
             this.player1.clickCard(this.gorrenrockBrawler);
+            this.player2.clickPrompt('Pass'); // no strange copy
             this.player2.clickDone(); // no guard
             this.player2.clickYes();
             expect(this.gorrenrockBrawler.damage).toBe(1);
@@ -84,10 +86,27 @@ describe('Gorrenrock Brawler', function () {
             expect(this.player1).toHaveDefaultPrompt();
         });
 
+        it('adds status when brawler was attacker and unit dies at end of turn', function () {
+            expect(this.gorrenrockBrawler.status).toBe(0);
+            this.player1.clickAttack(this.fluteMage);
+            this.player1.clickCard(this.gorrenrockBrawler);
+            this.player2.clickCard(this.strangeCopy); // strange copy
+            this.player2.clickDie(4);
+            this.player2.clickCard(this.fluteMage);
+            this.player2.clickCard(this.gorrenrockBrawler);
+            this.player2.clickDone(); // no guard
+            this.player2.clickYes();
+
+            this.player1.endTurn();
+
+            expect(this.gorrenrockBrawler.status).toBe(1); // flute mage dies after strange copy ends - failing
+        });
+
         it("doesn't add status when brawler was attacker and unit dies subsequent turn", function () {
             expect(this.gorrenrockBrawler.status).toBe(0);
             this.player1.clickAttack(this.dreadWraith);
             this.player1.clickCard(this.gorrenrockBrawler);
+            this.player2.clickPrompt('Pass'); // no strange copy
             this.player2.clickDone(); // no guard
             this.player2.clickYes();
             expect(this.gorrenrockBrawler.damage).toBe(1);

--- a/test/server/cards/GorrenrockBrawler.spec.js
+++ b/test/server/cards/GorrenrockBrawler.spec.js
@@ -47,7 +47,7 @@ describe('Gorrenrock Brawler', function () {
                     hand: ['iron-worker']
                 },
                 player2: {
-                    phoenixborn: 'rin-northfell',
+                    phoenixborn: 'brennen-blackcloud',
                     dicepool: ['ceremonial', 'time', 'charm', 'charm'],
                     hand: ['molten-gold'],
                     inPlay: ['flute-mage', 'dread-wraith']
@@ -82,6 +82,24 @@ describe('Gorrenrock Brawler', function () {
             this.player1.clickCard(this.dreadWraith);
             expect(this.gorrenrockBrawler.status).toBe(1);
             expect(this.player1).toHaveDefaultPrompt();
+        });
+
+        it("doesn't add status when brawler was attacker and unit dies subsequent turn", function () {
+            expect(this.gorrenrockBrawler.status).toBe(0);
+            this.player1.clickAttack(this.dreadWraith);
+            this.player1.clickCard(this.gorrenrockBrawler);
+            this.player2.clickDone(); // no guard
+            this.player2.clickYes();
+            expect(this.gorrenrockBrawler.damage).toBe(1);
+            expect(this.dreadWraith.damage).toBe(4);
+
+            this.player1.endTurn();
+            this.player2.clickCard(this.brennenBlackcloud);
+            this.player2.clickPrompt('Spirit Burn');
+            this.player2.clickCard(this.dreadWraith); // destroy my Dread Wraith
+            this.player2.clickCard(this.aradelSummergaard); // deal 2 damage to Aradel
+            expect(this.gorrenrockBrawler.status).toBe(0);
+            expect(this.player2).toHaveDefaultPrompt();
         });
     });
 


### PR DESCRIPTION
I can fix the specific bug by reseting wasAttacker and wasDefender when the player ends their turn, but I'm not sure if this may have other consequences. For example, I'm not sure whether a unit that has had Strange Copy applied and will be destroyed at the end of turn should result in the Brawler gaining a status token. I'll ask Discord > Rules to confirm