### PR TITLE
Improve discard and draw messages

### DIFF
--- a/server/game/GameActions/DiscardTopOfDeckAction.js
+++ b/server/game/GameActions/DiscardTopOfDeckAction.js
@@ -17,7 +17,9 @@ class DiscardTopOfDeckAction extends PlayerAction {
     }
 
     canAffect(player, context) {
-        return this.amount === 0 ? false : super.canAffect(player, context);
+        if (this.amount === 0 || player.deck.length === 0) {
+            return false;
+        } else return super.canAffect(player, context);
     }
 
     getEvent(player, context) {

--- a/server/game/cards/Ashes-Core/MistTyphoon.js
+++ b/server/game/cards/Ashes-Core/MistTyphoon.js
@@ -12,7 +12,7 @@ class MistTyphoon extends Card {
             then: {
                 alwaysTriggers: true,
                 may: 'draw a card',
-                gameAction: ability.actions.draw()
+                gameAction: ability.actions.draw({ showMessage: true })
             }
         });
     }

--- a/server/game/cards/Mono-Expansions/ParticleShield.js
+++ b/server/game/cards/Mono-Expansions/ParticleShield.js
@@ -16,7 +16,7 @@ class ParticleShield extends Card {
             })),
             then: {
                 alwaysTriggers: true,
-                gameAction: ability.actions.draw()
+                gameAction: ability.actions.draw({ showMessage: true })
             }
         });
     }

--- a/server/game/cards/Time/Concentration.js
+++ b/server/game/cards/Time/Concentration.js
@@ -17,7 +17,7 @@ class Concentration extends Card {
                 ability.actions.addStatusToken((context) => ({
                     target: context.player.phoenixborn
                 })),
-                ability.actions.draw(),
+                ability.actions.draw({ showMessage: true }),
                 ability.actions.changeDice({
                     dieCondition: (d) => d.exhausted,
                     unexhaust: true

--- a/server/game/cards/Time/FlockShepherd.js
+++ b/server/game/cards/Time/FlockShepherd.js
@@ -26,7 +26,7 @@ class FlockShepherd extends Card {
                 effect: AbilityDsl.effects.modifyAttack(2),
                 duration: 'untilEndOfTurn'
             })),
-            effect: 'increase the attack attack value of units with a printed attack of 0 by 2'
+            effect: 'increase the attack value of their 0 printed attack units by 2'
         });
     }
 }

--- a/server/game/cards/Time/RubyCobra.js
+++ b/server/game/cards/Time/RubyCobra.js
@@ -19,7 +19,7 @@ class RubyCobra extends Card {
             then: {
                 gameAction: ability.actions.discardTopOfDeck()
             },
-            effect: "increase its attack value by 1, and then discard opponent's top of deck"
+            effect: 'increase its attack value by 1'
         });
 
         this.persistentEffect({


### PR DESCRIPTION
Message fix for Ruby Cobra (now discard card is not automatically listed in the effect), also Flock Shepherd effect wording fix, and draw message when it is the second part of an effect.