### PR TITLE
Bug fix #818 Mirror Spirit now counts gravity flux tokens

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -830,7 +830,7 @@ class Card extends PlayableObject {
     }
 
     get exhaustionGravityFlux() {
-        return this.hasToken('gravityFlux') ? this.tokens.exhaustionGravityFlux : 0;
+        return this.hasToken('gravityFlux') ? this.tokens.gravityFlux : 0;
     }
 
     get exhausted() {

--- a/server/game/cards/Mixed-Expansions/MirrorSpirit.js
+++ b/server/game/cards/Mixed-Expansions/MirrorSpirit.js
@@ -25,7 +25,12 @@ class MirrorSpirit extends Card {
 
     getTokenCount(context) {
         const player = this.chosenValue ? context.player.opponent : context.player;
-        return player.unitsInPlay.reduce((acc, u) => acc + u.exhaustion, 0);
+        const exhaustionTotal = player.unitsInPlay.reduce((acc, u) => acc + u.exhaustion, 0);
+        const gravityFluxExhaustionTotal = player.unitsInPlay.reduce(
+            (acc, u) => acc + u.exhaustionGravityFlux,
+            0
+        );
+        return exhaustionTotal + gravityFluxExhaustionTotal;
     }
 }
 

--- a/test/server/cards/MirrorSpirit.spec.js
+++ b/test/server/cards/MirrorSpirit.spec.js
@@ -18,6 +18,7 @@ describe('mirror spirit enters play', function () {
         });
 
         this.gilder.tokens.exhaustion = 1;
+        this.gilder.tokens.gravityFlux = 1;
         this.mistSpirit.tokens.exhaustion = 2;
         this.ironWorker.tokens.exhaustion = 1;
     });
@@ -30,7 +31,7 @@ describe('mirror spirit enters play', function () {
         this.player1.clickCard(this.mirrorSpirit);
 
         this.player1.clickPrompt("Opponent's");
-        expect(this.mirrorSpirit.status).toBe(1);
+        expect(this.mirrorSpirit.status).toBe(2);
     });
 
     it('gets status tokens equal to exhaustion tokens (mine)', function () {


### PR DESCRIPTION
Fixed 2 bugs:
card.js method exhaustionGravityFlux wasn't searching for the right type of tokens and
Mirror Spirit wasn't counting gravityFlux tokens