### PR TITLE
Restrict Adept Duelist Disarm and enhance tests

### DIFF
--- a/server/game/cards/Time/AdeptDuelist.js
+++ b/server/game/cards/Time/AdeptDuelist.js
@@ -17,7 +17,7 @@ class AdeptDuelist extends Card {
                 optional: true,
                 activePromptTitle: 'Choose an alteration to discard',
                 cardType: UpgradeCardTypes,
-                // controller: 'opponent',
+                controller: 'opponent',
                 // condition: (card) => BattlefieldTypes.includes(card.parent.type),
                 gameAction: ability.actions.discard()
             }

--- a/test/server/cards/AdeptDuelist.spec.js
+++ b/test/server/cards/AdeptDuelist.spec.js
@@ -11,7 +11,8 @@ describe('Adept duelist', function () {
                 phoenixborn: 'aradel-summergaard',
                 inPlay: ['iron-rhino', 'mist-spirit', 'adept-duelist'],
                 dicepool: ['natural', 'illusion', 'ceremonial', 'charm'],
-                spellboard: ['cut-the-strings']
+                spellboard: ['cut-the-strings'],
+                hand: ['regress']
             }
         });
     });
@@ -26,5 +27,35 @@ describe('Adept duelist', function () {
         this.player2.clickCard(this.rootArmor); // remove this
 
         expect(this.rootArmor.location).toBe('discard');
+    });
+
+    it("removes own upgrade on opponent's unit", function () {
+        this.player1.playUpgrade(this.rootArmor, this.anchornaut);
+        this.player1.endTurn();
+        this.player2.clickCard(this.regress);
+        this.player2.clickPrompt('Play this alteration');
+        this.player2.clickCard(this.anchornaut);
+        this.player2.clickAttack(this.ironWorker);
+        this.player2.clickCard(this.adeptDuelist);
+        // reaction to onAttackersDeclared
+        this.player2.clickCard(this.adeptDuelist);
+        this.player2.clickCard(this.regress); // remove this
+
+        expect(this.regress.location).toBe('discard');
+    });
+
+    it("can't remove upgrade on own unit", function () {
+        this.player1.playUpgrade(this.rootArmor, this.anchornaut);
+        this.player1.endTurn();
+        this.player2.clickCard(this.regress);
+        this.player2.clickPrompt('Play this alteration');
+        this.player2.clickCard(this.adeptDuelist);
+        this.player2.clickAttack(this.ironWorker);
+        this.player2.clickCard(this.adeptDuelist);
+        // reaction to onAttackersDeclared
+        this.player2.clickCard(this.adeptDuelist);
+        this.player2.clickCard(this.regress); // cannot remove this
+
+        expect(this.regress.location).toBe('play area');
     });
 });


### PR DESCRIPTION
Disarm should only affect alterations on opposing units. Added restriction and confirmed via enhanced tests