### PR TITLE
Feature dice change targets

### DIFF
--- a/server/game/Die.js
+++ b/server/game/Die.js
@@ -186,6 +186,7 @@ class Die extends PlayableObject {
                         mode: 'upTo',
                         numDice: 2,
                         showCancel: true,
+                        dieCondition: (die) => !die.exhausted,
                         owner: 'opponent',
                         gameAction: this.game.actions.lowerDie()
                     },

--- a/server/game/Die.js
+++ b/server/game/Die.js
@@ -181,6 +181,7 @@ class Die extends PlayableObject {
                     title: 'Illusion Dice Power',
                     cost: [Costs.sideAction(), Costs.exhaustDie()],
                     target: {
+                        targetsPlayer: true,
                         toSelect: 'die',
                         mode: 'upTo',
                         numDice: 2,
@@ -340,6 +341,8 @@ class Die extends PlayableObject {
     setupAbilities() {
         switch (this.magic) {
             case 'illusion':
+                this.attachable = true;
+                break;
             case 'time':
                 this.attachable = true;
                 break;

--- a/server/game/cards/Ashes-Core/BloodShaman.js
+++ b/server/game/cards/Ashes-Core/BloodShaman.js
@@ -15,6 +15,7 @@ class BloodShaman extends Card {
                 alwaysTriggers: true,
                 target: {
                     toSelect: 'die',
+                    dieCondition: (die) => !die.exhausted,
                     owner: 'self',
                     gameAction: ability.actions.raiseDie({ showMessage: true })
                 }

--- a/server/game/cards/Ashes-Core/BloodShaman.js
+++ b/server/game/cards/Ashes-Core/BloodShaman.js
@@ -15,6 +15,7 @@ class BloodShaman extends Card {
                 alwaysTriggers: true,
                 target: {
                     toSelect: 'die',
+                    owner: 'self',
                     gameAction: ability.actions.raiseDie({ showMessage: true })
                 }
             }

--- a/server/game/cards/Ashes-Core/BloodShaman.js
+++ b/server/game/cards/Ashes-Core/BloodShaman.js
@@ -15,7 +15,7 @@ class BloodShaman extends Card {
                 alwaysTriggers: true,
                 target: {
                     toSelect: 'die',
-                    dieCondition: (die) => !die.exhausted,
+                    //dieCondition: (die) => !die.exhausted,
                     owner: 'self',
                     gameAction: ability.actions.raiseDie({ showMessage: true })
                 }

--- a/server/game/cards/Ashes-Core/CallUponTheRealms.js
+++ b/server/game/cards/Ashes-Core/CallUponTheRealms.js
@@ -5,6 +5,7 @@ class CallUponTheRealms extends Card {
         this.play({
             effect: 'change 3 dice in their active pool',
             gameAction: ability.actions.changeDice({
+                dieCondition: (die) => !die.exhausted,
                 numDice: 3,
                 owner: 'self'
             })

--- a/server/game/cards/Ashes-Core/HiddenPower.js
+++ b/server/game/cards/Ashes-Core/HiddenPower.js
@@ -7,6 +7,7 @@ class HiddenPower extends Card {
             gameAction: ability.actions.draw(),
             then: {
                 gameAction: ability.actions.changeDice({
+                    dieCondition: (die) => !die.exhausted,
                     numDice: 5,
                     owner: 'self'
                 })

--- a/server/game/cards/Ashes-Core/ShiftingMist.js
+++ b/server/game/cards/Ashes-Core/ShiftingMist.js
@@ -7,6 +7,7 @@ class ShiftingMist extends Card {
             cost: [ability.costs.sideAction(), ability.costs.exhaust()],
             location: 'spellboard',
             gameAction: ability.actions.changeDice({
+                dieCondition: (die) => !die.exhausted,
                 numDice: 2,
                 owner: 'self'
             })

--- a/server/game/cards/Deluxe/Accelerate.js
+++ b/server/game/cards/Deluxe/Accelerate.js
@@ -8,6 +8,7 @@ class Accelerate extends Card {
             gameAction: [
                 ability.actions.draw(),
                 ability.actions.changeDice({
+                    dieCondition: (die) => !die.exhausted,
                     numDice: 2,
                     owner: 'self'
                 }),

--- a/server/game/cards/Deluxe/MagicSyphon.js
+++ b/server/game/cards/Deluxe/MagicSyphon.js
@@ -7,9 +7,11 @@ class MagicSyphon extends Card {
             cost: [ability.costs.sideAction(), ability.costs.exhaust()],
             location: 'spellboard',
             gameAction: ability.actions.changeDice({
+                dieCondition: (die) => !die.exhausted,
                 owner: 'self'
             }),
             then: {
+                alwaysTriggers: true,
                 target: {
                     mode: 'select',
                     activePromptTitle: "Magic Syphon: Choose which player's dice pool to affect",
@@ -19,6 +21,7 @@ class MagicSyphon extends Card {
                 then: {
                     alwaysTriggers: true,
                     gameAction: ability.actions.changeDice((context) => ({
+                        dieCondition: (die) => !die.exhausted,
                         owner:
                             this.chosenValue === context.player.opponent.name ? 'opponent' : 'self'
                     }))

--- a/server/game/cards/Deluxe/MagicSyphon.js
+++ b/server/game/cards/Deluxe/MagicSyphon.js
@@ -7,18 +7,33 @@ class MagicSyphon extends Card {
             cost: [ability.costs.sideAction(), ability.costs.exhaust()],
             location: 'spellboard',
             gameAction: ability.actions.changeDice({
-                numDice: 1,
                 owner: 'self'
             }),
             then: {
-                //todo: this isn't right - need to target a player then select from their dice
-                alwaysTriggers: true,
-                gameAction: ability.actions.changeDice((context) => ({
-                    numDice: 1,
-                    owner: context.player.checkRestrictions('changeOpponentsDice') ? 'any' : 'self'
-                }))
+                target: {
+                    mode: 'select',
+                    activePromptTitle: "Magic Syphon: Choose which player's dice pool to affect",
+                    choices: (context) => this.getPlayerOptions(context),
+                    choiceHandler: (choice) => (this.chosenValue = choice.value)
+                },
+                then: {
+                    alwaysTriggers: true,
+                    gameAction: ability.actions.changeDice((context) => ({
+                        owner:
+                            this.chosenValue === context.player.opponent.name ? 'opponent' : 'self'
+                    }))
+                }
             }
         });
+    }
+
+    getPlayerOptions(context) {
+        let choices = [context.player.name];
+
+        if (context.player.checkRestrictions('changeOpponentsDice')) {
+            choices.push(context.player.opponent.name);
+        }
+        return choices.map((t) => ({ text: t, value: t }));
     }
 }
 

--- a/server/game/cards/Deluxe/ShatterPulse.js
+++ b/server/game/cards/Deluxe/ShatterPulse.js
@@ -15,13 +15,31 @@ class ShatterPulse extends Card {
                 gameAction: ability.actions.destroy()
             },
             then: {
-                //TODO: this needs restricting to a single player
-                gameAction: ability.actions.changeDice((context) => ({
-                    numDice: 2,
-                    owner: context.player.checkRestrictions('changeOpponentsDice') ? 'any' : 'self'
-                }))
+                target: {
+                    mode: 'select',
+                    activePromptTitle: "Shatter Pulse: Choose which player's dice pool to affect",
+                    choices: (context) => this.getPlayerOptions(context),
+                    choiceHandler: (choice) => (this.chosenValue = choice.value)
+                },
+                then: {
+                    alwaysTriggers: true,
+                    gameAction: ability.actions.changeDice((context) => ({
+                        numDice: 2,
+                        owner:
+                            this.chosenValue === context.player.opponent.name ? 'opponent' : 'self'
+                    }))
+                }
             }
         });
+    }
+
+    getPlayerOptions(context) {
+        let choices = [context.player.name];
+
+        if (context.player.checkRestrictions('changeOpponentsDice')) {
+            choices.push(context.player.opponent.name);
+        }
+        return choices.map((t) => ({ text: t, value: t }));
     }
 }
 

--- a/server/game/cards/Deluxe/ShatterPulse.js
+++ b/server/game/cards/Deluxe/ShatterPulse.js
@@ -24,6 +24,7 @@ class ShatterPulse extends Card {
                 then: {
                     alwaysTriggers: true,
                     gameAction: ability.actions.changeDice((context) => ({
+                        dieCondition: (die) => !die.exhausted,
                         numDice: 2,
                         owner:
                             this.chosenValue === context.player.opponent.name ? 'opponent' : 'self'

--- a/server/game/cards/Mixed-Expansions/ChangingWinds.js
+++ b/server/game/cards/Mixed-Expansions/ChangingWinds.js
@@ -38,7 +38,6 @@ class ChangingWinds extends Card {
             gameAction: ability.actions.draw(),
             then: {
                 gameAction: ability.actions.changeDice({
-                    numDice: 1,
                     owner: 'self'
                 })
             }

--- a/server/game/cards/Mixed-Expansions/ChangingWinds.js
+++ b/server/game/cards/Mixed-Expansions/ChangingWinds.js
@@ -38,6 +38,7 @@ class ChangingWinds extends Card {
             gameAction: ability.actions.draw(),
             then: {
                 gameAction: ability.actions.changeDice({
+                    dieCondition: (die) => !die.exhausted,
                     owner: 'self'
                 })
             }

--- a/server/game/cards/Mixed-Expansions/DarkReaping.js
+++ b/server/game/cards/Mixed-Expansions/DarkReaping.js
@@ -12,6 +12,7 @@ class DarkReaping extends Card {
             },
             then: {
                 gameAction: ability.actions.changeDice({
+                    dieCondition: (die) => !die.exhausted,
                     numDice: 5,
                     owner: 'self'
                 })

--- a/server/game/cards/Mixed-Expansions/Hollow.js
+++ b/server/game/cards/Mixed-Expansions/Hollow.js
@@ -9,6 +9,7 @@ class Hollow extends Card {
                 toSelect: 'die',
                 mode: 'upTo',
                 numDice: 2,
+                dieCondition: (die) => !die.exhausted,
                 owner: 'opponent',
                 gameAction: ability.actions.lowerDie()
             },

--- a/server/game/cards/Mixed-Expansions/Hollow.js
+++ b/server/game/cards/Mixed-Expansions/Hollow.js
@@ -5,6 +5,7 @@ class Hollow extends Card {
         this.entersPlay({
             title: 'Hex 2',
             target: {
+                targetsPlayer: true,
                 toSelect: 'die',
                 mode: 'upTo',
                 numDice: 2,

--- a/server/game/cards/Mixed-Expansions/NightsongCricket.js
+++ b/server/game/cards/Mixed-Expansions/NightsongCricket.js
@@ -4,10 +4,18 @@ class NightsongCricket extends Card {
     setupCardAbilities(ability) {
         this.destroyed({
             title: 'Polyphony',
-            gameAction: ability.actions.changeDice({
-                numDice: 1,
-                owner: 'any'
-            })
+            target: {
+                mode: 'select',
+                activePromptTitle: "Nightsong Cricket: Choose which player's dice pool to affect",
+                choices: (context) => this.getPlayerOptions(context),
+                choiceHandler: (choice) => (this.chosenValue = choice.value)
+            },
+            then: {
+                alwaysTriggers: true,
+                gameAction: ability.actions.changeDice((context) => ({
+                    owner: this.chosenValue === context.player.opponent.name ? 'opponent' : 'self'
+                }))
+            }
         });
 
         this.destroyed({
@@ -36,6 +44,15 @@ class NightsongCricket extends Card {
                 }
             }
         });
+    }
+
+    getPlayerOptions(context) {
+        let choices = [context.player.name];
+
+        if (context.player.checkRestrictions('changeOpponentsDice')) {
+            choices.push(context.player.opponent.name);
+        }
+        return choices.map((t) => ({ text: t, value: t }));
     }
 }
 

--- a/server/game/cards/Mixed-Expansions/NightsongCricket.js
+++ b/server/game/cards/Mixed-Expansions/NightsongCricket.js
@@ -13,6 +13,7 @@ class NightsongCricket extends Card {
             then: {
                 alwaysTriggers: true,
                 gameAction: ability.actions.changeDice((context) => ({
+                    dieCondition: (die) => !die.exhausted,
                     owner: this.chosenValue === context.player.opponent.name ? 'opponent' : 'self'
                 }))
             }

--- a/server/game/cards/Mixed-Expansions/TransmuteMagic.js
+++ b/server/game/cards/Mixed-Expansions/TransmuteMagic.js
@@ -37,6 +37,7 @@ class TransmuteMagic extends Card {
             then: {
                 alwaysTriggers: true,
                 gameAction: ability.actions.changeDice({
+                    dieCondition: (die) => !die.exhausted,
                     owner: 'self'
                 }),
                 then: {
@@ -44,6 +45,7 @@ class TransmuteMagic extends Card {
                     targetsPlayer: true,
                     condition: (context) => context.player.checkRestrictions('changeOpponentsDice'),
                     gameAction: ability.actions.changeDice({
+                        dieCondition: (die) => !die.exhausted,
                         owner: 'opponent'
                     })
                 }

--- a/server/game/cards/Mixed-Expansions/TransmuteMagic.js
+++ b/server/game/cards/Mixed-Expansions/TransmuteMagic.js
@@ -37,14 +37,13 @@ class TransmuteMagic extends Card {
             then: {
                 alwaysTriggers: true,
                 gameAction: ability.actions.changeDice({
-                    numDice: 1,
                     owner: 'self'
                 }),
                 then: {
                     alwaysTriggers: true,
+                    targetsPlayer: true,
                     condition: (context) => context.player.checkRestrictions('changeOpponentsDice'),
                     gameAction: ability.actions.changeDice({
-                        numDice: 1,
                         owner: 'opponent'
                     })
                 }

--- a/server/game/cards/Mono-Expansions/ShadowSpirit.js
+++ b/server/game/cards/Mono-Expansions/ShadowSpirit.js
@@ -11,6 +11,7 @@ class ShadowSpirit extends Card {
                 }
             },
             target: {
+                targetsPlayer: true,
                 activePromptTitle: 'Choose a die to lower',
                 optional: true,
                 toSelect: 'die',

--- a/server/game/cards/Mono-Expansions/ShadowSpirit.js
+++ b/server/game/cards/Mono-Expansions/ShadowSpirit.js
@@ -15,6 +15,7 @@ class ShadowSpirit extends Card {
                 activePromptTitle: 'Choose a die to lower',
                 optional: true,
                 toSelect: 'die',
+                dieCondition: (die) => !die.exhausted,
                 owner: 'opponent',
                 gameAction: ability.actions.lowerDie()
             }

--- a/server/game/cards/Mono-Expansions/Vanish.js
+++ b/server/game/cards/Mono-Expansions/Vanish.js
@@ -39,19 +39,28 @@ class Vanish extends Card {
         )
             return true;
 
-        // explicit targetting via gameAction owner property - this is for ChangeDice & ChangeDie triggers
+        // explicit targetting via gameAction owner property for ChangeDice triggers
         if (
             event.context.ability.gameAction.some(
-                (g) => g.owner === 'opponent' && (g.name === 'changeDice' || g.name === 'changeDie')
+                (g) => g.owner === 'opponent' && g.name === 'changeDice'
+            )
+        )
+            return true;
+
+        // implicit flag when targetting a die - used for lowerdie
+        if (
+            event.context.ability.targets.some(
+                (t) =>
+                    t instanceof AbilityTargetDie &&
+                    t.properties.targetsPlayer &&
+                    t.properties.owner === 'opponent'
             )
         )
             return true;
 
         // implicit flag when targetting a card - transfer does this for convenience
         const triggeringTargets = event.context.ability.targets.filter(
-            (t) =>
-                (t instanceof AbilityTargetCard || t instanceof AbilityTargetDie) &&
-                t.properties.targetsPlayer
+            (t) => t instanceof AbilityTargetCard && t.properties.targetsPlayer
         );
         return triggeringTargets.some(
             (t) => event.context.targets[t.name].controller === context.player

--- a/server/game/cards/Mono-Expansions/Vanish.js
+++ b/server/game/cards/Mono-Expansions/Vanish.js
@@ -1,5 +1,6 @@
 const { CardType } = require('../../../constants.js');
 const AbilityTargetCard = require('../../AbilityTargets/AbilityTargetCard.js');
+const AbilityTargetDie = require('../../AbilityTargets/AbilityTargetDie.js');
 const Card = require('../../Card.js');
 
 class Vanish extends Card {
@@ -38,9 +39,19 @@ class Vanish extends Card {
         )
             return true;
 
+        // explicit targetting via gameAction owner property - this is for ChangeDice & ChangeDie triggers
+        if (
+            event.context.ability.gameAction.some(
+                (g) => g.owner === 'opponent' && (g.name === 'changeDice' || g.name === 'changeDie')
+            )
+        )
+            return true;
+
         // implicit flag when targetting a card - transfer does this for convenience
         const triggeringTargets = event.context.ability.targets.filter(
-            (t) => t instanceof AbilityTargetCard && t.properties.targetsPlayer
+            (t) =>
+                (t instanceof AbilityTargetCard || t instanceof AbilityTargetDie) &&
+                t.properties.targetsPlayer
         );
         return triggeringTargets.some(
             (t) => event.context.targets[t.name].controller === context.player

--- a/server/game/cards/Mono-Expansions/VictoriaGlassfire.js
+++ b/server/game/cards/Mono-Expansions/VictoriaGlassfire.js
@@ -15,12 +15,13 @@ class VictoriaGlassfire extends Card {
             effect: "reroll {1} of their opponent's dice: {2}",
             effectArgs: (context) => [context.target.length, context.target],
             target: {
+                targetsPlayer: true,
                 toSelect: 'die',
                 dieCondition: (d) => !d.exhausted,
                 mode: 'upTo',
                 numDice: 4,
                 owner: 'opponent',
-                gameAction: ability.actions.rerollDice(),
+                gameAction: ability.actions.rerollDice()
             },
             then: (context) => ({
                 target: {

--- a/server/game/cards/Time/DreamFracture.js
+++ b/server/game/cards/Time/DreamFracture.js
@@ -9,11 +9,11 @@ class DreamFracture extends Card {
             title: 'Dream Fracture',
             cost: [ability.costs.mainAction(), ability.costs.exhaust()],
             location: 'spellboard',
-            //todo: this isn't right - need to target a player then select from their dice
             target: {
                 targetsPlayer: true,
                 activePromptTitle: 'Choose a die to lower',
                 toSelect: 'die',
+                dieCondition: (die) => !die.exhausted,
                 owner: 'opponent',
                 gameAction: ability.actions.lowerDie()
             },

--- a/server/game/cards/Time/DreamFracture.js
+++ b/server/game/cards/Time/DreamFracture.js
@@ -1,4 +1,3 @@
-const { CardType } = require('../../../constants.js');
 const Card = require('../../Card.js');
 
 class DreamFracture extends Card {
@@ -12,6 +11,7 @@ class DreamFracture extends Card {
             location: 'spellboard',
             //todo: this isn't right - need to target a player then select from their dice
             target: {
+                targetsPlayer: true,
                 activePromptTitle: 'Choose a die to lower',
                 toSelect: 'die',
                 owner: 'opponent',
@@ -20,11 +20,10 @@ class DreamFracture extends Card {
             then: {
                 condition: (context) =>
                     !context.player.opponent.dice.some((d) => d.level === 'power' && !d.exhausted),
-                target: {
-                    cardType: CardType.Phoenixborn,
-                    controller: 'opponent',
-                    gameAction: ability.actions.dealDamage({ showMessage: true })
-                }
+                gameAction: ability.actions.dealDamage((context) => ({
+                    target: context.player.opponent.phoenixborn,
+                    showMessage: true
+                }))
             }
         });
     }

--- a/server/game/cards/Time/DreamlockMage.js
+++ b/server/game/cards/Time/DreamlockMage.js
@@ -7,8 +7,9 @@ class DreamlockMage extends Card {
             title: 'Restrict 1',
             cost: [ability.costs.sideAction()],
             target: {
+                targetsPlayer: true,
                 toSelect: 'die',
-                dieCondition: (die) => die.level === Level.Power,
+                dieCondition: (die) => die.level === Level.Power && !die.exhausted,
                 owner: 'opponent',
                 gameAction: ability.actions.lowerDie()
             }

--- a/server/game/cards/Time/FoxSpirit.js
+++ b/server/game/cards/Time/FoxSpirit.js
@@ -8,6 +8,7 @@ class FoxSpirit extends Card {
                 activePromptTitle: 'Choose a die to raise',
                 optional: true,
                 toSelect: 'die',
+                dieCondition: (die) => !die.exhausted,
                 owner: 'self',
                 gameAction: ability.actions.raiseDie()
             }

--- a/server/game/cards/Time/VoidPulse.js
+++ b/server/game/cards/Time/VoidPulse.js
@@ -33,12 +33,12 @@ class VoidPulse extends Card {
                     then: {
                         alwaysTriggers: true,
                         gameAction: ability.actions.changeDice((context) => ({
+                            dieCondition: (die) => !die.exhausted,
                             numDice: 2,
                             owner:
                                 this.chosenValue === context.player.opponent.name
                                     ? 'opponent'
-                                    : 'self',
-                            dieCondition: (die) => !die.exhausted
+                                    : 'self'
                         }))
                     }
                 }

--- a/test/server/attack-phoenixborn-removal.spec.js
+++ b/test/server/attack-phoenixborn-removal.spec.js
@@ -108,6 +108,7 @@ describe('Attack Removals', function () {
             this.player2.clickDie(0);
             this.player2.clickDone();
             this.player2.clickCard(this.hammerKnight);
+            this.player2.clickPrompt('player1');
             this.player2.clickDone(); // no dice fixing
 
             expect(this.game.attackState.battles.length).toBe(2);

--- a/test/server/cards/BloodShaman.spec.js
+++ b/test/server/cards/BloodShaman.spec.js
@@ -29,6 +29,7 @@ describe('Blood Shaman', function () {
         this.player1.clickCard(this.bloodShaman);
 
         expect(this.player1).toHavePrompt('Choose a die');
+        expect(this.player1).not.toBeAbleToSelectDie(this.player2.dicepool[0]);
         this.player1.clickDie(0);
 
         expect(this.aradelSummergaard.damage).toBe(0);

--- a/test/server/cards/Keepsake.spec.js
+++ b/test/server/cards/Keepsake.spec.js
@@ -52,10 +52,13 @@ describe('Keepsake', function () {
             this.player1.clickDie(0);
             this.player1.clickDie(0);
             this.player1.clickDone();
-            this.player1.clickOpponentDie(0);
-            this.player1.clickDone();
+            this.player1.clickPrompt('player2');
 
-            expect(this.player2.dicepool[0].level).toBe('basic');
+            this.player1.clickOpponentDie(1);
+            this.player1.clickDone();
+            // Due to re-ordering, should only check die[1] or die[3]
+            expect(this.player2.dicepool[1].level).toBe('basic');
+
             expect(this.player1).toHaveDefaultPrompt();
             expect(this.keepsake.status).toBe(1);
         });

--- a/test/server/cards/LawOfAssurance.spec.js
+++ b/test/server/cards/LawOfAssurance.spec.js
@@ -85,6 +85,8 @@ describe('law of Assurance', function () {
             this.player1.clickPrompt('Magic Syphon');
             this.player1.clickDie(0);
             this.player1.clickPrompt('done');
+            expect(this.player1).not.toHavePromptButton('player2');
+
             expect(this.player1).toBeAbleToSelectDie(this.player1.dicepool[0]);
             expect(this.player1).not.toBeAbleToSelectDie(this.player2.dicepool[0]);
         });
@@ -111,9 +113,10 @@ describe('law of Assurance', function () {
             this.player1.clickCard(this.magicSyphon);
             this.player1.clickPrompt('Magic Syphon');
             this.player1.clickDie(0);
-            this.player1.clickPrompt('done');
-            expect(this.player1).toBeAbleToSelectDie(this.player1.dicepool[0]);
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('player2');
             expect(this.player1).toBeAbleToSelectDie(this.player2.dicepool[0]);
+            expect(this.player1).not.toBeAbleToSelectDie(this.player1.dicepool[1]);
         });
     });
 });

--- a/test/server/cards/MagicSyphon.spec.js
+++ b/test/server/cards/MagicSyphon.spec.js
@@ -17,7 +17,7 @@ describe('Magic Syphon', function () {
         });
     });
 
-    it('changes one of my dice then one of anyones', function () {
+    it("changes one of my dice then one of my opponent's", function () {
         this.player1.clickCard(this.magicSyphon);
         this.player1.clickPrompt('Magic Syphon');
 
@@ -25,14 +25,32 @@ describe('Magic Syphon', function () {
         this.player1.clickDie(1);
         expect(this.player1.dicepool[1].level).toBe('class');
         this.player1.clickPrompt('Done');
+        this.player1.clickPrompt('player2');
+        expect(this.player1).not.toBeAbleToSelectDie(this.player1.dicepool[0]);
         this.player1.clickOpponentDie(0);
         this.player1.clickOpponentDie(0);
         expect(this.player2.dicepool[0].level).toBe('class');
         this.player1.clickOpponentDie(0);
         this.player1.clickOpponentDie(0); // deselect
 
+        this.player1.clickPrompt('Done');
+
+        expect(this.player1).toHaveDefaultPrompt();
+    });
+
+    it('changes one of my dice then one of mine', function () {
+        this.player1.clickCard(this.magicSyphon);
+        this.player1.clickPrompt('Magic Syphon');
+
+        this.player1.clickDie(1);
+        this.player1.clickDie(1);
+        expect(this.player1.dicepool[1].level).toBe('class');
+        this.player1.clickPrompt('Done');
+        this.player1.clickPrompt('player1');
+        expect(this.player1).not.toBeAbleToSelectDie(this.player2.dicepool[0]);
         this.player1.clickDie(0);
         this.player1.clickDie(0);
+        //this.player1.clickDie(0);
         expect(this.player1.dicepool[0].level).toBe('class');
         this.player1.clickPrompt('Done');
 

--- a/test/server/cards/Vanish.spec.js
+++ b/test/server/cards/Vanish.spec.js
@@ -96,7 +96,8 @@ describe('Vanish', function () {
                 player1: {
                     phoenixborn: 'leo-sunshadow',
                     inPlay: ['enchanted-violinist'],
-                    dicepool: ['ceremonial', 'natural', 'natural', 'charm'],
+                    spellboard: ['magic-syphon'],
+                    dicepool: ['ceremonial', 'natural', 'natural', 'charm', 'illusion'],
                     hand: ['anguish', 'one-hundred-blades']
                 },
                 player2: {
@@ -125,6 +126,29 @@ describe('Vanish', function () {
             expect(this.player2.hand.length).toBe(handSize - 1);
         });
 
+        it('should cancel magic syphon', function () {
+            this.player1.clickCard(this.magicSyphon);
+            this.player1.clickPrompt('Magic Syphon');
+
+            this.player1.clickDie(1);
+            this.player1.clickDie(1);
+            expect(this.player1.dicepool[1].level).toBe('class');
+            this.player1.clickPrompt('Done');
+            this.player1.clickPrompt('player2');
+            expect(this.player2).toHavePrompt('Any Reactions to magic syphon targetting you?');
+            this.player2.clickCard(this.vanish);
+            expect(this.player1).toHaveDefaultPrompt();
+        });
+
+        it('should cancel illusion power', function () {
+            this.player1.clickDie(4);
+            this.player1.clickPrompt('Illusion Dice Power');
+            //this.player1.clickOpponentDie(1);
+            //this.player1.clickOpponentDie(2);
+            expect(this.player2).toHavePrompt('Any Reactions to Illusion Dice Power targetting you?');
+            this.player2.clickCard(this.vanish);
+            expect(this.player1).toHaveDefaultPrompt();
+        });
     });
 
     describe('interaction with final cry', function () {

--- a/test/server/cards/Vanish.spec.js
+++ b/test/server/cards/Vanish.spec.js
@@ -95,7 +95,7 @@ describe('Vanish', function () {
             this.setupTest({
                 player1: {
                     phoenixborn: 'leo-sunshadow',
-                    inPlay: ['enchanted-violinist'],
+                    inPlay: ['enchanted-violinist', 'dreamlock-mage'],
                     spellboard: ['magic-syphon'],
                     dicepool: ['ceremonial', 'natural', 'natural', 'charm', 'illusion'],
                     hand: ['anguish', 'one-hundred-blades']
@@ -140,14 +140,27 @@ describe('Vanish', function () {
             expect(this.player1).toHaveDefaultPrompt();
         });
 
-        it('should cancel illusion power', function () {
-            this.player1.clickDie(4);
-            this.player1.clickPrompt('Illusion Dice Power');
-            //this.player1.clickOpponentDie(1);
-            //this.player1.clickOpponentDie(2);
-            expect(this.player2).toHavePrompt('Any Reactions to Illusion Dice Power targetting you?');
+        it('should cancel dreamlock mage power', function () {
+            this.player1.clickCard(this.dreamlockMage);
+            this.player1.clickPrompt('Restrict 1');
+            this.player1.clickOpponentDie(1);
+            expect(this.player2).toHavePrompt('Any Reactions to Restrict 1?');
             this.player2.clickCard(this.vanish);
             expect(this.player1).toHaveDefaultPrompt();
+            expect(this.player2.dicepool[1].level).toBe('power');
+        });
+
+        it('should cancel illusion die power', function () {
+            this.player1.clickDie(4);
+            this.player1.clickPrompt('Illusion Dice Power');
+            this.player1.clickOpponentDie(1);
+            this.player1.clickOpponentDie(2);
+            this.player1.clickPrompt('Done');
+            expect(this.player2).toHavePrompt('Any Reactions to Illusion Dice Power?');
+            this.player2.clickCard(this.vanish);
+            expect(this.player1).toHaveDefaultPrompt();
+            expect(this.player2.dicepool[1].level).toBe('power');
+            expect(this.player2.dicepool[2].level).toBe('power');
         });
     });
 

--- a/test/server/cards/VoidPulse.spec.js
+++ b/test/server/cards/VoidPulse.spec.js
@@ -11,7 +11,7 @@ describe('Void pulse', function () {
                 },
                 player2: {
                     phoenixborn: 'rin-northfell',
-                    dicepool: ['ceremonial', 'time', 'charm', 'charm'],
+                    dicepool: ['ceremonial', 'charm', 'charm', 'time'],
                     hand: ['molten-gold'],
                     inPlay: ['mist-spirit', 'sonic-swordsman']
                 }
@@ -38,13 +38,14 @@ describe('Void pulse', function () {
 
             expect(this.player1.deck.length).toBe(myDeck - 2); // drew 2 cards
             // change dice
+            this.player1.clickPrompt('player2');
             this.player1.clickOpponentDie(0);
-            this.player1.clickOpponentDie(1);
+            this.player1.clickOpponentDie(3); // This is to avoid the duplicate charm dice, which tend to cause havoc with reordering
 
-            this.player1.clickDone(); // finishes all card effects
+            this.player1.clickDone(); // finish all card effects
 
             expect(this.player2.dicepool[0].level).toBe('basic');
-            expect(this.player2.dicepool[1].level).toBe('basic');
+            expect(this.player2.dicepool[3].level).toBe('basic');
 
             expect(this.voidPulse.location).toBe('discard');
             expect(this.sonicSwordsman.location).toBe('discard');

--- a/test/server/dice-cycle.spec.js
+++ b/test/server/dice-cycle.spec.js
@@ -60,6 +60,7 @@ describe('Dice cycle', function () {
         expect(this.mistSpirit.location).toBe('archives');
         expect(target.level).toBe('power');
 
+        this.player2.clickPrompt('player1');
         this.player2.clickOpponentDie(0);
         expect(target.level).toBe('basic');
         expect(this.player2.player.selectedDice.length).toBe(1);

--- a/test/server/dice-cycle.spec.js
+++ b/test/server/dice-cycle.spec.js
@@ -55,30 +55,30 @@ describe('Dice cycle', function () {
 
         this.player2.clickCard(this.mistSpirit); // destroy
 
-        const target = this.player1.dicepool[0];
+        const target = this.player1.dicepool[2];
 
         expect(this.mistSpirit.location).toBe('archives');
         expect(target.level).toBe('power');
 
         this.player2.clickPrompt('player1');
-        this.player2.clickOpponentDie(0);
+        this.player2.clickOpponentDie(2);
         expect(target.level).toBe('basic');
         expect(this.player2.player.selectedDice.length).toBe(1);
 
-        this.player2.clickOpponentDie(0);
+        this.player2.clickOpponentDie(2);
         expect(target.level).toBe('class');
         expect(this.player2.player.selectedDice.length).toBe(1);
 
-        this.player2.clickOpponentDie(0);
+        this.player2.clickOpponentDie(2);
         expect(target.level).toBe('power');
         expect(this.player2.player.selectedDice.length).toBe(1);
 
-        this.player2.clickOpponentDie(0);
+        this.player2.clickOpponentDie(2);
         expect(target.level).toBe('power');
         expect(this.player2.player.selectedDice.length).toBe(0);
 
-        this.player2.clickOpponentDie(0); // add as basic
-        this.player2.clickOpponentDie(0); // increase to class
+        this.player2.clickOpponentDie(2); // add as basic
+        this.player2.clickOpponentDie(2); // increase to class
         this.player2.clickPrompt('Done');
         expect(target.level).toBe('class');
     });


### PR DESCRIPTION
Significant level of changes. In summary:

- ChangeDice actions now trigger Vanish by checking the owner
- LowerDie actions now trigger Vanish by setting the targetsPlayer flag
- ChangeDice, LowerDie, RaiseDie & RerollDie consistently don't allow the die selected to be exhausted

I think that these changes together should resolve Issue #915 