### PR TITLE
Reset reaction counter consistently

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1260,6 +1260,8 @@ class Game extends EventEmitter {
     endTurn() {
         this.betweenTurns = true;
         this.activePlayer.endTurn();
+        this.activePlayer.limitedPlayed = 0; // reset reaction count for next turn
+        this.activePlayer.opponent.limitedPlayed = 0; // reset reaction count for next turn
         this.cardsDiscarded = [];
         this.effectsUsed = [];
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -295,7 +295,7 @@ class Player extends GameObject {
         this.passedMain = false;
         this.turn += 1;
         this.actions = { main: true, side: 1 };
-        this.limitedPlayed = 0; // reset for my turn
+        //this.limitedPlayed = 0; // reset for my turn - moved to game.js
         this.game.addAlert('startofturn', `Turn ${this.turn} - {0}`, this);
         if (this.game.suddenDeath) {
             this.doSuddenDeathDiscard();
@@ -331,7 +331,7 @@ class Player extends GameObject {
         if (this.passedMain) {
             this.game.addAlert('info', '{0} PASSES their main action', this);
         }
-        this.limitedPlayed = 0; // reset for opponent's turn
+        //this.limitedPlayed = 0; // reset for opponent's turn - moved to game.js
         this.cardsInPlay.forEach((c) => {
             c.new = false;
 

--- a/test/server/cards/SummonSleepingWidows.spec.js
+++ b/test/server/cards/SummonSleepingWidows.spec.js
@@ -50,7 +50,7 @@ describe('Summon Sleeping Widows', function () {
                         'ceremonial',
                         'ceremonial'
                     ],
-                    spellboard: ['summon-blood-puppet', 'sleeping-widow', 'sleeping-widow'],
+                    spellboard: ['summon-blood-puppet'],
                     archives: ['blood-puppet'],
                     hand: ['summon-sleeping-widows']
                 },
@@ -80,6 +80,62 @@ describe('Summon Sleeping Widows', function () {
             expect(this.bloodPuppet.location).toBe('archives');
 
             expect(this.player2).toHaveDefaultPrompt();
+        });
+    });
+
+    describe('Reaction used when duplicate effect ends', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    phoenixborn: 'hope-everthorn',
+                    inPlay: ['iron-worker', 'shadow-spirit'],
+                    dicepool: [
+                        'natural',
+                        'illusion',
+                        'charm',
+                        'ceremonial',
+                        'ceremonial',
+                        'ceremonial'
+                    ],
+                    spellboard: ['summon-shadow-spirit'],
+                    archives: [
+                        'sleeping-widow',
+                        'sleeping-widow',
+                        'shadow-spirit',
+                        'shadow-spirit'
+                    ],
+                    hand: ['summon-sleeping-widows', 'final-cry']
+                },
+                player2: {
+                    phoenixborn: 'coal-roarkwin',
+                    inPlay: ['anchornaut'],
+                    spellboard: [],
+                    dicepool: ['natural', 'illusion', 'ceremonial', 'ceremonial']
+                }
+            });
+        });
+
+        it("does not use next turn's reaction", function () {
+            this.player1.clickCard(this.hopeEverthorn);
+            this.player1.clickPrompt('Duplicate');
+            this.player1.clickDie(0);
+            this.player1.clickCard(this.shadowSpirit);
+            this.player1.clickCard(this.summonShadowSpirit);
+
+            this.player1.clickPrompt('Summon Shadow Spirit');
+
+            this.player1.endTurn();
+
+            expect(this.player1).toHavePrompt('Any reactions to Shadow Spirit being destroyed?');
+            this.player1.clickCard(this.summonSleepingWidows);
+            expect(this.player1.player.limitedPlayed).toBe(1);
+
+            this.player2.clickDie(0);
+            this.player2.clickPrompt('Natural Dice Power');
+            this.player2.clickCard(this.sleepingWidow);
+            //expect(this.player1.player.limitedPlayed).toBe(0);
+
+            //expect(this.player1).toHavePrompt('Any reactions to Sleeping Widow being destroyed?'); // Failing as reaction already used?
         });
     });
 });


### PR DESCRIPTION
I moved the limitedPlayed reset to the game.js endturn step, rather than having it inside player.js
I'm not sure if this is the best way of doing it, but it worked for the test that was originally failing as it ensured that the reaction counter was reset after the player endturn step.