### PR TITLE
Fix Dockerfile for Lobby/Node Services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app
 COPY package-lock.json /usr/src/app
+RUN apt-get update && apt-get install -y libpango1.0-dev
 RUN npm install
 COPY . /usr/src/app
 EXPOSE 49153


### PR DESCRIPTION
Fixes the Dockerfile for running the "lobby" and "node" services in docker-compose.

The node:16 base image does not have pangocairo available.  This results in "RUN npm install" failing if the library is not installed beforehand.